### PR TITLE
Command line parameter for test filename

### DIFF
--- a/Wangscape/Wangscape.vcxproj
+++ b/Wangscape/Wangscape.vcxproj
@@ -86,8 +86,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
-      <AdditionalIncludeDirectories>
-      </AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)</AdditionalIncludeDirectories>
     </ClCompile>
     <PostBuildEvent>
       <Command>lib /NOLOGO /OUT:"$(TargetPath).lib" "$(ProjectDir)\$(Configuration)\*.obj"</Command>
@@ -101,8 +100,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
-      <AdditionalIncludeDirectories>
-      </AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)</AdditionalIncludeDirectories>
     </ClCompile>
     <PostBuildEvent>
       <Command>lib /NOLOGO /OUT:"$(TargetPath).lib" "$(ProjectDir)\$(Configuration)\*.obj"</Command>

--- a/Wangscape/noise/Reseedable.cpp
+++ b/Wangscape/noise/Reseedable.cpp
@@ -24,14 +24,10 @@ Reseedable Reseedable::abs()
 
 Reseedable Reseedable::clamp(double lower, double upper)
 {
-    auto clamp_p = std::make_shared<module::Clamp>();
-    clamp_p->SetSourceModule(0, *module);
-    clamp_p->SetBounds(lower, upper);
-
-    auto result = std::make_shared<module::ModuleGroup>();
-    result->insert("source", *this)
-           .insert("output", makeReseedable(clamp_p));
-    return makeReseedable(result);
+    assert(lower <= upper);
+    // noise::module::Clamp cannot be used here because it asserts
+    // lower < upper
+    return max(lower).min(upper);
 }
 
 Reseedable Reseedable::exp(double base)

--- a/WangscapeTest/OptionsFilename.cpp
+++ b/WangscapeTest/OptionsFilename.cpp
@@ -1,0 +1,21 @@
+#include "OptionsFilename.h"
+#include <stdexcept>
+
+namespace
+{
+std::string filename;
+bool filenameSet = false;
+}
+
+const std::string& getOptionsFilename()
+{
+    return filename;
+}
+
+void setOptionsFilename(const std::string & optionsFilename)
+{
+    if (filenameSet)
+        throw std::runtime_error("Options filename already set");
+    filename = optionsFilename;
+    filenameSet = true;
+}

--- a/WangscapeTest/OptionsFilename.cpp
+++ b/WangscapeTest/OptionsFilename.cpp
@@ -15,7 +15,12 @@ const std::string& getOptionsFilename()
 void setOptionsFilename(const std::string & optionsFilename)
 {
     if (filenameSet)
+    {
         throw std::runtime_error("Options filename already set");
-    filename = optionsFilename;
-    filenameSet = true;
+    }
+    else
+    {
+        filename = optionsFilename;
+        filenameSet = true;
+    }
 }

--- a/WangscapeTest/OptionsFilename.h
+++ b/WangscapeTest/OptionsFilename.h
@@ -1,0 +1,5 @@
+#pragma once
+#include <string>
+
+const std::string& getOptionsFilename();
+void setOptionsFilename(const std::string& filename);

--- a/WangscapeTest/TestCornerCombiner.cpp
+++ b/WangscapeTest/TestCornerCombiner.cpp
@@ -3,7 +3,8 @@
 #include <noise/module/CornerCombinerBase.h>
 #include <noise/module/ModuleFactories.h>
 
-class TestCornerCombiner : public ::testing::Test {
+class TestCornerCombiner : public ::testing::Test
+{
 protected:
     noise::module::CornerCombinerBase cc1;
     noise::module::CornerCombinerBase cc05;

--- a/WangscapeTest/TestEdgeFavouringMask.cpp
+++ b/WangscapeTest/TestEdgeFavouringMask.cpp
@@ -2,7 +2,8 @@
 #include <noise/module/NormLPQ.h>
 #include <noise/module/ModuleFactories.h>
 
-class TestEdgeFavouringMask : public ::testing::Test {
+class TestEdgeFavouringMask : public ::testing::Test
+{
 protected:
     noise::Reseedable n1_1;
     noise::Reseedable n1_2;

--- a/WangscapeTest/TestMetaOutput.cpp
+++ b/WangscapeTest/TestMetaOutput.cpp
@@ -17,7 +17,6 @@
 class TestMetaOutput : public TestRequiringOptions
 {
 protected:
-    using TestRequiringOptions::TestRequiringOptions;
     tilegen::TilesetGenerator tg;
     const metaoutput::MetaOutput& mo;
     TestMetaOutput() :

--- a/WangscapeTest/TestMetaOutput.cpp
+++ b/WangscapeTest/TestMetaOutput.cpp
@@ -12,17 +12,18 @@
 #include <tilegen/TilesetGenerator.h>
 #include <tilegen/partition/TilePartitionerSquares.h>
 
-class TestMetaOutput : public ::testing::Test {
+#include "TestRequiringOptions.h"
+
+class TestMetaOutput : public TestRequiringOptions
+{
 protected:
-    std::string filename;
+    using TestRequiringOptions::TestRequiringOptions;
     tilegen::TilesetGenerator tg;
-    const OptionsManager optionsManager;
     const metaoutput::MetaOutput& mo;
     TestMetaOutput() :
-        filename("../Wangscape/example/example_options.json"),
-        optionsManager(filename),
-        tg(optionsManager.getOptions(),
-           std::move(std::make_unique<tilegen::partition::TilePartitionerSquares>(optionsManager.getOptions()))),
+        TestRequiringOptions(),
+        tg(options,
+           std::move(std::make_unique<tilegen::partition::TilePartitionerSquares>(options))),
         mo(tg.mo)
     {
         tg.generate([&](const sf::Texture& output, std::string filename) {});

--- a/WangscapeTest/TestModuleGroup.cpp
+++ b/WangscapeTest/TestModuleGroup.cpp
@@ -2,7 +2,8 @@
 
 #include <noise/module/ModuleFactories.h>
 
-class TestModuleGroup : public ::testing::Test {
+class TestModuleGroup : public ::testing::Test
+{
 protected:
     noise::Reseedable rs;
     TestModuleGroup() :

--- a/WangscapeTest/TestMovingScaleBias.cpp
+++ b/WangscapeTest/TestMovingScaleBias.cpp
@@ -2,7 +2,8 @@
 
 #include <noise/module/ModuleFactories.h>
 
-class TestMovingScaleBias : public ::testing::Test {
+class TestMovingScaleBias : public ::testing::Test
+{
 protected:
     noise::Reseedable x;
     noise::Reseedable y;

--- a/WangscapeTest/TestNormLPQ.cpp
+++ b/WangscapeTest/TestNormLPQ.cpp
@@ -2,7 +2,8 @@
 #include <noise/module/NormLPQ.h>
 #include <noise/module/ModuleFactories.h>
 
-class TestNormLPQ : public ::testing::Test {
+class TestNormLPQ : public ::testing::Test
+{
 protected:
     noise::ModulePtr n1_1;
     noise::ModulePtr n1_2;

--- a/WangscapeTest/TestOptions.cpp
+++ b/WangscapeTest/TestOptions.cpp
@@ -10,14 +10,17 @@
 class TestOptions : public TestRequiringOptions
 {
 protected:
-    using TestRequiringOptions::TestRequiringOptions;
+    TestOptions() :
+        TestRequiringOptions()
+    {
+    }
 };
 
 TEST_F(TestOptions, TestOptionsValues)
 {
-    EXPECT_EQ(options.filename, getFilename()) <<
+    EXPECT_EQ(options.filename, optionsFilename) <<
         "Incorrect options filename";
-    boost::filesystem::path expected_output_dir(getFilename());
+    boost::filesystem::path expected_output_dir(optionsFilename);
     expected_output_dir.remove_filename();
     expected_output_dir /= "output";
     EXPECT_TRUE(boost::filesystem::equivalent(

--- a/WangscapeTest/TestOptions.cpp
+++ b/WangscapeTest/TestOptions.cpp
@@ -5,28 +5,23 @@
 #include <Options.h>
 #include <OptionsManager.h>
 
-class TestOptions : public ::testing::Test {
-protected:
-    std::string filename;
-    const Options& options;
-    const OptionsManager optionsManager;
+#include "TestRequiringOptions.h"
 
-    TestOptions() :
-        filename("../../Wangscape/example/example_options.json"),
-        optionsManager(filename),
-        options(optionsManager.getOptions())
-    {
-    };
-    ~TestOptions() {};
+class TestOptions : public TestRequiringOptions {
+protected:
+    using TestRequiringOptions::TestRequiringOptions;
 };
 
 TEST_F(TestOptions, TestOptionsValues)
 {
     EXPECT_EQ(options.filename, filename) <<
         "Incorrect options filename";
+    boost::filesystem::path expected_output_dir(filename);
+    expected_output_dir.remove_filename();
+    expected_output_dir /= "output";
     EXPECT_TRUE(boost::filesystem::equivalent(
         boost::filesystem::path(options.relativeOutputDirectory),
-        boost::filesystem::path("../../Wangscape/example/output"))) <<
+        expected_output_dir)) <<
         "Incorrect relative output directory";
     EXPECT_STREQ(options.outputDirectory.c_str(),
                  "output") <<

--- a/WangscapeTest/TestOptions.cpp
+++ b/WangscapeTest/TestOptions.cpp
@@ -7,7 +7,8 @@
 
 #include "TestRequiringOptions.h"
 
-class TestOptions : public TestRequiringOptions {
+class TestOptions : public TestRequiringOptions
+{
 protected:
     using TestRequiringOptions::TestRequiringOptions;
 };

--- a/WangscapeTest/TestOptions.cpp
+++ b/WangscapeTest/TestOptions.cpp
@@ -14,9 +14,9 @@ protected:
 
 TEST_F(TestOptions, TestOptionsValues)
 {
-    EXPECT_EQ(options.filename, filename) <<
+    EXPECT_EQ(options.filename, getFilename()) <<
         "Incorrect options filename";
-    boost::filesystem::path expected_output_dir(filename);
+    boost::filesystem::path expected_output_dir(getFilename());
     expected_output_dir.remove_filename();
     expected_output_dir /= "output";
     EXPECT_TRUE(boost::filesystem::equivalent(

--- a/WangscapeTest/TestRequiringOptions.cpp
+++ b/WangscapeTest/TestRequiringOptions.cpp
@@ -1,24 +1,9 @@
 #include "TestRequiringOptions.h"
-
-bool TestRequiringOptions::initFilename(std::string filename)
-{
-    if(mFilenameSet)
-        return false;
-    mFilename = filename;
-    mFilenameSet = true;
-    return true;
-}
+#include "OptionsFilename.h"
 
 TestRequiringOptions::TestRequiringOptions() :
-    optionsManager(mFilename),
+    optionsFilename(getOptionsFilename()),
+    optionsManager(optionsFilename),
     options(optionsManager.getOptions())
 {
 }
-
-const std::string & TestRequiringOptions::getFilename()
-{
-    return mFilename;
-}
-
-bool TestRequiringOptions::mFilenameSet;
-std::string TestRequiringOptions::mFilename;

--- a/WangscapeTest/TestRequiringOptions.cpp
+++ b/WangscapeTest/TestRequiringOptions.cpp
@@ -1,8 +1,24 @@
 #include "TestRequiringOptions.h"
 
+bool TestRequiringOptions::initFilename(std::string filename)
+{
+    if(mFilenameSet)
+        return false;
+    mFilename = filename;
+    mFilenameSet = true;
+    return true;
+}
+
 TestRequiringOptions::TestRequiringOptions() :
-    filename("Wangscape/example/example_options.json"),
-    optionsManager(filename),
+    optionsManager(mFilename),
     options(optionsManager.getOptions())
 {
 }
+
+const std::string & TestRequiringOptions::getFilename()
+{
+    return mFilename;
+}
+
+bool TestRequiringOptions::mFilenameSet;
+std::string TestRequiringOptions::mFilename;

--- a/WangscapeTest/TestRequiringOptions.cpp
+++ b/WangscapeTest/TestRequiringOptions.cpp
@@ -1,0 +1,19 @@
+#include <gtest/gtest.h>
+
+#include <Options.h>
+#include <OptionsManager.h>
+
+class TestRequiringOptions : public ::testing::Test {
+protected:
+    std::string filename;
+    const Options& options;
+    const OptionsManager optionsManager;
+
+    TestRequiringOptions() :
+        filename("../../Wangscape/example/example_options.json"),
+        optionsManager(filename),
+        options(optionsManager.getOptions())
+    {
+    };
+   virtual ~TestRequiringOptions() = default;
+};

--- a/WangscapeTest/TestRequiringOptions.cpp
+++ b/WangscapeTest/TestRequiringOptions.cpp
@@ -1,19 +1,8 @@
-#include <gtest/gtest.h>
+#include "TestRequiringOptions.h"
 
-#include <Options.h>
-#include <OptionsManager.h>
-
-class TestRequiringOptions : public ::testing::Test {
-protected:
-    std::string filename;
-    const Options& options;
-    const OptionsManager optionsManager;
-
-    TestRequiringOptions() :
-        filename("../../Wangscape/example/example_options.json"),
-        optionsManager(filename),
-        options(optionsManager.getOptions())
-    {
-    };
-   virtual ~TestRequiringOptions() = default;
-};
+TestRequiringOptions::TestRequiringOptions() :
+    filename("../../Wangscape/example/example_options.json"),
+    optionsManager(filename),
+    options(optionsManager.getOptions())
+{
+}

--- a/WangscapeTest/TestRequiringOptions.cpp
+++ b/WangscapeTest/TestRequiringOptions.cpp
@@ -1,7 +1,7 @@
 #include "TestRequiringOptions.h"
 
 TestRequiringOptions::TestRequiringOptions() :
-    filename("../../Wangscape/example/example_options.json"),
+    filename("Wangscape/example/example_options.json"),
     optionsManager(filename),
     options(optionsManager.getOptions())
 {

--- a/WangscapeTest/TestRequiringOptions.h
+++ b/WangscapeTest/TestRequiringOptions.h
@@ -5,12 +5,18 @@
 #include <Options.h>
 #include <OptionsManager.h>
 
-class TestRequiringOptions : public ::testing::Test {
+class TestRequiringOptions : public ::testing::Test
+{
+public:
+    static bool initFilename(std::string filename);
 protected:
-    std::string filename;
     const Options& options;
     const OptionsManager optionsManager;
 
     TestRequiringOptions();
     virtual ~TestRequiringOptions() = default;
+    static const std::string& getFilename();
+private:
+    static std::string mFilename;
+    static bool mFilenameSet;
 };

--- a/WangscapeTest/TestRequiringOptions.h
+++ b/WangscapeTest/TestRequiringOptions.h
@@ -8,15 +8,11 @@
 class TestRequiringOptions : public ::testing::Test
 {
 public:
-    static bool initFilename(std::string filename);
 protected:
+    const std::string optionsFilename;
     const Options& options;
     const OptionsManager optionsManager;
 
     TestRequiringOptions();
     virtual ~TestRequiringOptions() = default;
-    static const std::string& getFilename();
-private:
-    static std::string mFilename;
-    static bool mFilenameSet;
 };

--- a/WangscapeTest/TestRequiringOptions.h
+++ b/WangscapeTest/TestRequiringOptions.h
@@ -1,0 +1,14 @@
+#include <gtest/gtest.h>
+
+#include <Options.h>
+#include <OptionsManager.h>
+
+class TestRequiringOptions : public ::testing::Test {
+protected:
+    std::string filename;
+    const Options& options;
+    const OptionsManager optionsManager;
+
+    TestRequiringOptions();
+    virtual ~TestRequiringOptions() = default;
+};

--- a/WangscapeTest/TestRequiringOptions.h
+++ b/WangscapeTest/TestRequiringOptions.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <gtest/gtest.h>
 
 #include <Options.h>

--- a/WangscapeTest/TestReseedable.cpp
+++ b/WangscapeTest/TestReseedable.cpp
@@ -3,7 +3,8 @@
 #include <noise/MakeReseedable.h>
 #include <noise/module/ModuleFactories.h>
 
-class TestReseedable : public ::testing::Test {
+class TestReseedable : public ::testing::Test
+{
 protected:
     noise::Reseedable x;
     noise::Reseedable y;

--- a/WangscapeTest/TestTileGenerationPlan.cpp
+++ b/WangscapeTest/TestTileGenerationPlan.cpp
@@ -6,7 +6,8 @@
 #include <random>
 
 using Reseedable = noise::Reseedable;
-class TestTileGenerationPlan : public ::testing::Test {
+class TestTileGenerationPlan : public ::testing::Test
+{
 protected:
     Reseedable x;
     Reseedable y;

--- a/WangscapeTest/TestTilePartitionerGradient.cpp
+++ b/WangscapeTest/TestTilePartitionerGradient.cpp
@@ -4,17 +4,15 @@
 #include <Options.h>
 #include <OptionsManager.h>
 
-class TestTilePartitionerGradient : public ::testing::Test{
+#include "TestRequiringOptions.h"
+
+class TestTilePartitionerGradient : public TestRequiringOptions
+{
 protected:
-    std::string filename;
     tilegen::partition::TilePartitionerGradient tpg;
     tilegen::partition::TilePartitionerGradient::TilePartition tp;
-    const Options& options;
-    const OptionsManager optionsManager;
     TestTilePartitionerGradient() :
-        filename("../Wangscape/example/example_options.json"),
-        optionsManager(filename),
-        options(optionsManager.getOptions()),
+        TestRequiringOptions(),
         tpg(options)
     {
     };

--- a/WangscapeTest/TestTilePartitionerSquares.cpp
+++ b/WangscapeTest/TestTilePartitionerSquares.cpp
@@ -2,18 +2,17 @@
 #include <tilegen/partition/TilePartitionerSquares.h>
 #include <Options.h>
 #include <OptionsManager.h>
-class TestTilePartitionerSquares : public ::testing::Test {
+
+#include "TestRequiringOptions.h"
+
+class TestTilePartitionerSquares : public TestRequiringOptions
+{
 protected:
-    std::string filename;
-    const Options& options;
-    const OptionsManager optionsManager;
     tilegen::partition::TilePartitionerSquares tps;
     tilegen::partition::TilePartitionerSquares::TilePartition tp;
     
     TestTilePartitionerSquares() :
-        filename("../Wangscape/example/example_options.json"),
-        optionsManager(filename),
-        options(optionsManager.getOptions()),
+        TestRequiringOptions(),
         tps(options)
     {
         tps.makePartition(tp, { "g","g","s","s" });

--- a/WangscapeTest/TestTilesetGenerator.cpp
+++ b/WangscapeTest/TestTilesetGenerator.cpp
@@ -4,16 +4,14 @@
 #include <tilegen/TilesetGenerator.h>
 #include <tilegen/partition/TilePartitionerSquares.h>
 
-class TestTilesetGenerator : public ::testing::Test {
+#include "TestRequiringOptions.h"
+
+class TestTilesetGenerator : public TestRequiringOptions
+{
 protected:
-    std::string filename;
-    const Options& options;
-    const OptionsManager optionsManager;
     tilegen::TilesetGenerator tg;
     TestTilesetGenerator():
-        filename("../Wangscape/example/example_options.json"),
-        optionsManager(filename),
-        options(optionsManager.getOptions()),
+        TestRequiringOptions(),
         tg(options, std::move(std::make_unique<tilegen::partition::TilePartitionerSquares>(options)))
     {
 

--- a/WangscapeTest/WangscapeTest.vcxproj
+++ b/WangscapeTest/WangscapeTest.vcxproj
@@ -158,6 +158,7 @@
     <ClCompile Include="TestMovingScaleBias.cpp" />
     <ClCompile Include="TestNormLPQ.cpp" />
     <ClCompile Include="TestOptions.cpp" />
+    <ClCompile Include="TestRequiringOptions.cpp" />
     <ClCompile Include="TestReseedable.cpp" />
     <ClCompile Include="TestTileGenerationPlan.cpp" />
     <ClCompile Include="TestTilePartitionerGradient.cpp" />

--- a/WangscapeTest/WangscapeTest.vcxproj
+++ b/WangscapeTest/WangscapeTest.vcxproj
@@ -151,6 +151,7 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="main.cpp" />
+    <ClCompile Include="OptionsFilename.cpp" />
     <ClCompile Include="TestCornerCombiner.cpp" />
     <ClCompile Include="TestEdgeFavouringMask.cpp" />
     <ClCompile Include="TestMetaOutput.cpp" />
@@ -169,6 +170,7 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="OptionsFilename.h" />
     <ClInclude Include="TestRequiringOptions.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/WangscapeTest/WangscapeTest.vcxproj
+++ b/WangscapeTest/WangscapeTest.vcxproj
@@ -168,6 +168,9 @@
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="TestRequiringOptions.h" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
     <Import Project="..\packages\googletest.v140.windesktop.static.rt-dyn.1.7.0.1\build\native\googletest.v140.windesktop.static.rt-dyn.targets" Condition="Exists('..\packages\googletest.v140.windesktop.static.rt-dyn.1.7.0.1\build\native\googletest.v140.windesktop.static.rt-dyn.targets')" />

--- a/WangscapeTest/WangscapeTest.vcxproj.filters
+++ b/WangscapeTest/WangscapeTest.vcxproj.filters
@@ -61,4 +61,9 @@
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="TestRequiringOptions.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
 </Project>

--- a/WangscapeTest/WangscapeTest.vcxproj.filters
+++ b/WangscapeTest/WangscapeTest.vcxproj.filters
@@ -57,12 +57,18 @@
     <ClCompile Include="TestRequiringOptions.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="OptionsFilename.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="TestRequiringOptions.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="OptionsFilename.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/WangscapeTest/WangscapeTest.vcxproj.filters
+++ b/WangscapeTest/WangscapeTest.vcxproj.filters
@@ -54,6 +54,9 @@
     <ClCompile Include="TestTilePartitionerSquares.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="TestRequiringOptions.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/WangscapeTest/main.cpp
+++ b/WangscapeTest/main.cpp
@@ -12,4 +12,4 @@ int main(int argc, char** argv)
     std::cout << "Using options file at " << filename << "\n";
     assert(TestRequiringOptions::initFilename(filename));
     return RUN_ALL_TESTS();
-}
+} 

--- a/WangscapeTest/main.cpp
+++ b/WangscapeTest/main.cpp
@@ -4,6 +4,12 @@
 int main(int argc, char** argv)
 {
     ::testing::InitGoogleTest(&argc, argv);
-    assert(TestRequiringOptions::initFilename("Wangscape/example/example_options.json"));
+    std::string filename;
+    if (argc < 2)
+        filename = std::string("Wangscape/example/example_options.json");
+    else
+        filename = std::string(argv[1]);
+    std::cout << "Using options file at " << filename << "\n";
+    assert(TestRequiringOptions::initFilename(filename));
     return RUN_ALL_TESTS();
 }

--- a/WangscapeTest/main.cpp
+++ b/WangscapeTest/main.cpp
@@ -1,5 +1,5 @@
 #include <gtest/gtest.h>
-#include "TestRequiringOptions.h"
+#include "OptionsFilename.h"
 
 int main(int argc, char** argv)
 {
@@ -10,6 +10,6 @@ int main(int argc, char** argv)
     else
         filename = std::string(argv[1]);
     std::cout << "Using options file at " << filename << "\n";
-    assert(TestRequiringOptions::initFilename(filename));
+    setOptionsFilename(filename);
     return RUN_ALL_TESTS();
 } 

--- a/WangscapeTest/main.cpp
+++ b/WangscapeTest/main.cpp
@@ -1,6 +1,9 @@
 #include <gtest/gtest.h>
+#include "TestRequiringOptions.h"
 
-int main(int argc, char** argv) {
+int main(int argc, char** argv)
+{
     ::testing::InitGoogleTest(&argc, argv);
+    assert(TestRequiringOptions::initFilename("Wangscape/example/example_options.json"));
     return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
This is a quick and rather dirty solution to #44.
* Path to `example_options.json` is passed as an optional command line parameter
* Filename is detected by raw comparison of `argc` after gtest options are consumed; this can be migrated to boost::program_options if preferred.
* If the filename is not detected, a fallback value is used (starting from the project root).
* The filename is used to initialise an evil static data member of a class.
* The same class is used as a base class for tests which need to access the options filename or parsed file.

I tried to do this using [value-parametrised tests](https://github.com/google/googletest/blob/master/googletest/docs/AdvancedGuide.md#value-parameterized-tests), but initialising the values in `main` doesn't seem to be a well-supported use case.