### PR TITLE
No double-to-float conversions

### DIFF
--- a/Wangscape/noise/RasterValues.cpp
+++ b/Wangscape/noise/RasterValues.cpp
@@ -56,7 +56,6 @@ size_t RasterValues<T>::index(size_t x, size_t y) const
     return y*mSizeX + x;
 }
 
-template class RasterValues<float>;
 template class RasterValues<double>;
 
 } // namespace noise

--- a/Wangscape/tilegen/alpha/AlphaCalculatorBase.h
+++ b/Wangscape/tilegen/alpha/AlphaCalculatorBase.h
@@ -11,7 +11,7 @@ namespace alpha
 class AlphaCalculatorBase
 {
 public:
-    typedef std::vector<float> Weights;
+    typedef std::vector<double> Weights;
     typedef std::vector<sf::Uint8> Alphas;
 
     AlphaCalculatorBase();

--- a/Wangscape/tilegen/alpha/AlphaCalculatorLinear.cpp
+++ b/Wangscape/tilegen/alpha/AlphaCalculatorLinear.cpp
@@ -11,8 +11,8 @@ namespace alpha
 void AlphaCalculatorLinear::updateAlphasAux(const Weights& weights)
 {
     int alpha_remaining = 255;
-    float total_weight = std::accumulate(weights.cbegin(), weights.cend(), 0.f);
-    if (total_weight <= std::numeric_limits<float>::epsilon() * 255 * 4)
+    double total_weight = std::accumulate(weights.cbegin(), weights.cend(), 0.);
+    if (total_weight <= std::numeric_limits<double>::epsilon() * 255 * 4)
     {
         // This shouldn't happen, but it is easy to make weight masks
         // where this does happen.

--- a/Wangscape/tilegen/partition/TilePartitionerGradient.cpp
+++ b/Wangscape/tilegen/partition/TilePartitionerGradient.cpp
@@ -25,7 +25,7 @@ void TilePartitionerGradient::makePartition(TilePartition & regions,
                    mOptions.tileFormat.resolution);
         masks.push_back(img);
     }
-    std::vector<float> weights(corners.size(), 0.f);
+    std::vector<double> weights(corners.size(), 0.);
     const int resolution_sub_1 = mOptions.tileFormat.resolution - 1;
     const int quarter_res = mOptions.tileFormat.resolution / 4;
     alpha::AlphaCalculatorLinear ac;
@@ -33,10 +33,10 @@ void TilePartitionerGradient::makePartition(TilePartition & regions,
     {
         for (size_t y = 0; y < mOptions.tileFormat.resolution; y++)
         {
-            weights[0] = (float)gradientWeight(x, y, 0, 0, quarter_res);
-            weights[1] = (float)gradientWeight(x, y, 0, resolution_sub_1, quarter_res);
-            weights[2] = (float)gradientWeight(x, y, resolution_sub_1, 0, quarter_res);
-            weights[3] = (float)gradientWeight(x, y, resolution_sub_1, resolution_sub_1, quarter_res);
+            weights[0] = (double)gradientWeight(x, y, 0, 0, quarter_res);
+            weights[1] = (double)gradientWeight(x, y, 0, resolution_sub_1, quarter_res);
+            weights[2] = (double)gradientWeight(x, y, resolution_sub_1, 0, quarter_res);
+            weights[3] = (double)gradientWeight(x, y, resolution_sub_1, resolution_sub_1, quarter_res);
             ac.updateAlphas(weights);
             const auto& alphas = ac.getAlphas();
             for (size_t i = 0; i < masks.size(); i++)

--- a/Wangscape/tilegen/partition/TilePartitionerGradient.cpp
+++ b/Wangscape/tilegen/partition/TilePartitionerGradient.cpp
@@ -33,10 +33,10 @@ void TilePartitionerGradient::makePartition(TilePartition & regions,
     {
         for (size_t y = 0; y < mOptions.tileFormat.resolution; y++)
         {
-            weights[0] = (double)gradientWeight(x, y, 0, 0, quarter_res);
-            weights[1] = (double)gradientWeight(x, y, 0, resolution_sub_1, quarter_res);
-            weights[2] = (double)gradientWeight(x, y, resolution_sub_1, 0, quarter_res);
-            weights[3] = (double)gradientWeight(x, y, resolution_sub_1, resolution_sub_1, quarter_res);
+            weights[0] = static_cast<double>(gradientWeight(x, y, 0, 0, quarter_res));
+            weights[1] = static_cast<double>(gradientWeight(x, y, 0, resolution_sub_1, quarter_res));
+            weights[2] = static_cast<double>(gradientWeight(x, y, resolution_sub_1, 0, quarter_res));
+            weights[3] = static_cast<double>(gradientWeight(x, y, resolution_sub_1, resolution_sub_1, quarter_res));
             ac.updateAlphas(weights);
             const auto& alphas = ac.getAlphas();
             for (size_t i = 0; i < masks.size(); i++)

--- a/Wangscape/tilegen/partition/TilePartitionerPerlin.cpp
+++ b/Wangscape/tilegen/partition/TilePartitionerPerlin.cpp
@@ -2,7 +2,7 @@
 #include "noise/module/ModuleFactories.h"
 #include "noise/RasterValues.h"
 #include "noise/module/Pow.h"
-#include "tilegen/alpha/AlphaCalculatorMax.h"
+#include "tilegen/alpha/AlphaCalculatorLinear.h"
 
 namespace tilegen
 {
@@ -29,16 +29,16 @@ Reseedable TilePartitionerPerlin::makeCornerModule(const Corners& corners,
     Reseedable ef = noise::module::makeEdgeFavouringMask(1.5, 1.);
     Reseedable corner = ef.blend(stochastic_mask, deterministic);
     // postprocess should be customisable
-    Reseedable postprocess = corner.pow(5.).clamp(0.,std::numeric_limits<float>::infinity());
+    Reseedable postprocess = corner.pow(5.).clamp(0.,std::numeric_limits<double>::infinity());
     return postprocess;
 }
 
-void TilePartitionerPerlin::noiseToAlpha(std::vector<noise::RasterValues<float>>& noise_values,
+void TilePartitionerPerlin::noiseToAlpha(std::vector<noise::RasterValues<double>>& noise_values,
                                          std::vector<sf::Image>& outputs,
                                          size_t resolution) const
 {
-    std::vector<float> weights((int)CORNERS);
-    alpha::AlphaCalculatorMax ac;
+    std::vector<double> weights((int)CORNERS);
+    alpha::AlphaCalculatorLinear ac;
     for (size_t x = 0; x < resolution; x++)
     {
         for (size_t y = 0; y < resolution; y++)
@@ -61,7 +61,7 @@ void TilePartitionerPerlin::noiseToAlpha(std::vector<noise::RasterValues<float>>
 void TilePartitionerPerlin::makePartition(TilePartition & regions, const Corners& corners)
 {
     // Prepare noise value storage
-    std::vector<noise::RasterValues<float>> noise_values;
+    std::vector<noise::RasterValues<double>> noise_values;
     for (int i = 0; i < (int)CORNERS; i++)
     {
         noise_values.emplace_back(mOptions.tileFormat.resolution,

--- a/Wangscape/tilegen/partition/TilePartitionerPerlin.h
+++ b/Wangscape/tilegen/partition/TilePartitionerPerlin.h
@@ -20,7 +20,7 @@ public:
     void makePartition(TilePartition& regions,
                        const Corners& corners);
     Reseedable makeCornerModule(const Corners & corners, bool left, bool top);
-    void noiseToAlpha(std::vector<noise::RasterValues<float>>& noise_values,
+    void noiseToAlpha(std::vector<noise::RasterValues<double>>& noise_values,
                       std::vector<sf::Image>& outputs,
                       size_t resolution) const;
 private:


### PR DESCRIPTION
Corner weights from `TilePartitionerGradient` and `TilePartitionerPerlin` were being converted from doubles to floats before `AlphaCalculator` methods were applied. I don't think there's any good reason to do that. This PR removes all of those conversions.

These conversions were a suspected cause of #51. The issue remains unresolved, but the size and frequency of black patches may have been reduced.