### PR TITLE
AlphaCalculator options

### DIFF
--- a/Wangscape/Options.h
+++ b/Wangscape/Options.h
@@ -5,6 +5,7 @@
 #include <vector>
 #include "common.h"
 #include "metaoutput/Filenames.h"
+#include "tilegen/alpha/AlphaCalculatorMode.h"
 #include "TerrainSpec.h"
 #include "TileFormat.h"
 
@@ -22,6 +23,7 @@ public:
     metaoutput::Filenames outputFilenames;
     TerrainSpecMap terrains;
     CliqueList cliques;
+    tilegen::alpha::AlphaCalculatorMode alphaCalculatorMode;
     
     virtual ~Options() = default;
 };

--- a/Wangscape/Options.h
+++ b/Wangscape/Options.h
@@ -5,7 +5,7 @@
 #include <vector>
 #include "common.h"
 #include "metaoutput/Filenames.h"
-#include "tilegen/alpha/AlphaCalculatorMode.h"
+#include "tilegen/alpha/CalculatorMode.h"
 #include "TerrainSpec.h"
 #include "TileFormat.h"
 
@@ -23,7 +23,7 @@ public:
     metaoutput::Filenames outputFilenames;
     TerrainSpecMap terrains;
     CliqueList cliques;
-    tilegen::alpha::AlphaCalculatorMode alphaCalculatorMode;
+    tilegen::alpha::CalculatorMode CalculatorMode;
     
     virtual ~Options() = default;
 };

--- a/Wangscape/OptionsManager.cpp
+++ b/Wangscape/OptionsManager.cpp
@@ -1,6 +1,7 @@
 #include "OptionsManager.h"
 
 #include <fstream>
+#include <iostream>
 
 #include <boost/filesystem.hpp>
 
@@ -23,8 +24,18 @@ void OptionsManager::loadOptions(std::string optionsFilename)
 
     std::string str{std::istreambuf_iterator<char>(ifs),
                     std::istreambuf_iterator<char>()};
-
-    mOptions = spotify::json::decode<Options>(str.c_str());
+    try
+    {
+        mOptions = spotify::json::decode<Options>(str.c_str());
+    }
+    catch (spotify::json::decode_exception e)
+    {
+        std::cout << "spotify::json::decode_exception encountered at "
+            << e.offset()
+            << ": "
+            << e.what();
+        throw;
+    }
     mOptions.filename = optionsFilename;
 
     createOutputDirectory(optionsFilename);

--- a/Wangscape/OptionsManager.cpp
+++ b/Wangscape/OptionsManager.cpp
@@ -28,7 +28,7 @@ void OptionsManager::loadOptions(std::string optionsFilename)
     {
         mOptions = spotify::json::decode<Options>(str.c_str());
     }
-    catch (spotify::json::decode_exception e)
+    catch (const spotify::json::decode_exception& e)
     {
         std::cout << "spotify::json::decode_exception encountered at "
             << e.offset()

--- a/Wangscape/Wangscape.vcxproj
+++ b/Wangscape/Wangscape.vcxproj
@@ -183,10 +183,10 @@
     <ClInclude Include="TerrainImages.h" />
     <ClInclude Include="TerrainSpec.h" />
     <ClInclude Include="TileFormat.h" />
-    <ClInclude Include="tilegen\alpha\AlphaCalculatorBase.h" />
-    <ClInclude Include="tilegen\alpha\AlphaCalculatorLinear.h" />
-    <ClInclude Include="tilegen\alpha\AlphaCalculatorMax.h" />
-    <ClInclude Include="tilegen\alpha\AlphaCalculatorMode.h" />
+    <ClInclude Include="tilegen\alpha\CalculatorBase.h" />
+    <ClInclude Include="tilegen\alpha\CalculatorLinear.h" />
+    <ClInclude Include="tilegen\alpha\CalculatorMax.h" />
+    <ClInclude Include="tilegen\alpha\CalculatorMode.h" />
     <ClInclude Include="tilegen\partition\TilePartitionerBase.h" />
     <ClInclude Include="tilegen\partition\TilePartitionerGradient.h" />
     <ClInclude Include="tilegen\partition\TilePartitionerPerlin.h" />
@@ -212,9 +212,9 @@
     <ClCompile Include="Main.cpp" />
     <ClCompile Include="OptionsManager.cpp" />
     <ClCompile Include="TerrainImages.cpp" />
-    <ClCompile Include="tilegen\alpha\AlphaCalculatorBase.cpp" />
-    <ClCompile Include="tilegen\alpha\AlphaCalculatorLinear.cpp" />
-    <ClCompile Include="tilegen\alpha\AlphaCalculatorMax.cpp" />
+    <ClCompile Include="tilegen\alpha\CalculatorBase.cpp" />
+    <ClCompile Include="tilegen\alpha\CalculatorLinear.cpp" />
+    <ClCompile Include="tilegen\alpha\CalculatorMax.cpp" />
     <ClCompile Include="tilegen\partition\TilePartitionerBase.cpp" />
     <ClCompile Include="tilegen\partition\TilePartitionerGradient.cpp" />
     <ClCompile Include="tilegen\partition\TilePartitionerPerlin.cpp" />

--- a/Wangscape/Wangscape.vcxproj
+++ b/Wangscape/Wangscape.vcxproj
@@ -186,6 +186,7 @@
     <ClInclude Include="tilegen\alpha\AlphaCalculatorBase.h" />
     <ClInclude Include="tilegen\alpha\AlphaCalculatorLinear.h" />
     <ClInclude Include="tilegen\alpha\AlphaCalculatorMax.h" />
+    <ClInclude Include="tilegen\alpha\AlphaCalculatorMode.h" />
     <ClInclude Include="tilegen\partition\TilePartitionerBase.h" />
     <ClInclude Include="tilegen\partition\TilePartitionerGradient.h" />
     <ClInclude Include="tilegen\partition\TilePartitionerPerlin.h" />

--- a/Wangscape/Wangscape.vcxproj.filters
+++ b/Wangscape/Wangscape.vcxproj.filters
@@ -191,6 +191,9 @@
     <ClInclude Include="TileFormat.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="tilegen\alpha\AlphaCalculatorMode.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="Main.cpp">

--- a/Wangscape/Wangscape.vcxproj.filters
+++ b/Wangscape/Wangscape.vcxproj.filters
@@ -134,15 +134,6 @@
     <ClInclude Include="tilegen\partition\TilePartitionerPerlin.h">
       <Filter>Header Files\tilegen\partition</Filter>
     </ClInclude>
-    <ClInclude Include="tilegen\alpha\AlphaCalculatorMax.h">
-      <Filter>Header Files\tilegen\alpha</Filter>
-    </ClInclude>
-    <ClInclude Include="tilegen\alpha\AlphaCalculatorBase.h">
-      <Filter>Header Files\tilegen\alpha</Filter>
-    </ClInclude>
-    <ClInclude Include="tilegen\alpha\AlphaCalculatorLinear.h">
-      <Filter>Header Files\tilegen\alpha</Filter>
-    </ClInclude>
     <ClInclude Include="Corners.h">
       <Filter>Header Files</Filter>
     </ClInclude>
@@ -191,7 +182,16 @@
     <ClInclude Include="TileFormat.h">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="tilegen\alpha\AlphaCalculatorMode.h">
+    <ClInclude Include="tilegen\alpha\CalculatorBase.h">
+      <Filter>Header Files\tilegen\alpha</Filter>
+    </ClInclude>
+    <ClInclude Include="tilegen\alpha\CalculatorLinear.h">
+      <Filter>Header Files\tilegen\alpha</Filter>
+    </ClInclude>
+    <ClInclude Include="tilegen\alpha\CalculatorMax.h">
+      <Filter>Header Files\tilegen\alpha</Filter>
+    </ClInclude>
+    <ClInclude Include="tilegen\alpha\CalculatorMode.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>
@@ -250,15 +250,6 @@
     <ClCompile Include="tilegen\partition\TilePartitionerSquares.cpp">
       <Filter>Source Files\tilegen\partition</Filter>
     </ClCompile>
-    <ClCompile Include="tilegen\alpha\AlphaCalculatorBase.cpp">
-      <Filter>Source Files\tilegen\alpha</Filter>
-    </ClCompile>
-    <ClCompile Include="tilegen\alpha\AlphaCalculatorLinear.cpp">
-      <Filter>Source Files\tilegen\alpha</Filter>
-    </ClCompile>
-    <ClCompile Include="tilegen\alpha\AlphaCalculatorMax.cpp">
-      <Filter>Source Files\tilegen\alpha</Filter>
-    </ClCompile>
     <ClCompile Include="OptionsManager.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -273,6 +264,15 @@
     </ClCompile>
     <ClCompile Include="metaoutput\Tileset.cpp">
       <Filter>Source Files\metaoutput</Filter>
+    </ClCompile>
+    <ClCompile Include="tilegen\alpha\CalculatorBase.cpp">
+      <Filter>Source Files\tilegen\alpha</Filter>
+    </ClCompile>
+    <ClCompile Include="tilegen\alpha\CalculatorLinear.cpp">
+      <Filter>Source Files\tilegen\alpha</Filter>
+    </ClCompile>
+    <ClCompile Include="tilegen\alpha\CalculatorMax.cpp">
+      <Filter>Source Files\tilegen\alpha</Filter>
     </ClCompile>
   </ItemGroup>
 </Project>

--- a/Wangscape/codecs/OptionsCodec.h
+++ b/Wangscape/codecs/OptionsCodec.h
@@ -25,7 +25,11 @@ struct default_codec_t<Options>
         codec.required("TileFormat", &Options::tileFormat);
         codec.required("Cliques", &Options::cliques);
         codec.required("MetaOutput", &Options::outputFilenames);
-
+        codec.required("AlphaCalculatorMode", &Options::alphaCalculatorMode,
+                       codec::enumeration<tilegen::alpha::AlphaCalculatorMode, std::string>({
+                           {tilegen::alpha::AlphaCalculatorMode::Max, "Max"},
+                           {tilegen::alpha::AlphaCalculatorMode::Linear, "Linear"}}));
+        
         return codec;
     }
 };

--- a/Wangscape/codecs/OptionsCodec.h
+++ b/Wangscape/codecs/OptionsCodec.h
@@ -25,10 +25,10 @@ struct default_codec_t<Options>
         codec.required("TileFormat", &Options::tileFormat);
         codec.required("Cliques", &Options::cliques);
         codec.required("MetaOutput", &Options::outputFilenames);
-        codec.required("AlphaCalculatorMode", &Options::alphaCalculatorMode,
-                       codec::enumeration<tilegen::alpha::AlphaCalculatorMode, std::string>({
-                           {tilegen::alpha::AlphaCalculatorMode::Max, "Max"},
-                           {tilegen::alpha::AlphaCalculatorMode::Linear, "Linear"}}));
+        codec.required("CalculatorMode", &Options::CalculatorMode,
+                       codec::enumeration<tilegen::alpha::CalculatorMode, std::string>({
+                           {tilegen::alpha::CalculatorMode::Max, "Max"},
+                           {tilegen::alpha::CalculatorMode::Linear, "Linear"}}));
         
         return codec;
     }

--- a/Wangscape/codecs/OptionsCodec.h
+++ b/Wangscape/codecs/OptionsCodec.h
@@ -25,7 +25,7 @@ struct default_codec_t<Options>
         codec.required("TileFormat", &Options::tileFormat);
         codec.required("Cliques", &Options::cliques);
         codec.required("MetaOutput", &Options::outputFilenames);
-        codec.required("CalculatorMode", &Options::CalculatorMode,
+        codec.required("AlphaCalculatorMode", &Options::CalculatorMode,
                        codec::enumeration<tilegen::alpha::CalculatorMode, std::string>({
                            {tilegen::alpha::CalculatorMode::Max, "Max"},
                            {tilegen::alpha::CalculatorMode::Linear, "Linear"}}));

--- a/Wangscape/example/example_options.json
+++ b/Wangscape/example/example_options.json
@@ -37,5 +37,6 @@
     {
       "Terrains": ["s", "g"]
     }
-  ]
+  ],
+  "AlphaCalculatorMode":"Max"
 }

--- a/Wangscape/example3/example_options.json
+++ b/Wangscape/example3/example_options.json
@@ -51,5 +51,6 @@
     {
       "Terrains": ["s", "g"]
     }
-  ]
+  ],
+  "AlphaCalculatorMode":"Linear"
 }

--- a/Wangscape/options_schema.json
+++ b/Wangscape/options_schema.json
@@ -123,7 +123,6 @@
           },
           "required": [
             "FullName",
-            "ShortName",
             "FileName"
           ]
         }
@@ -180,6 +179,14 @@
           "Terrains"
         ]
       }
+    },
+    "AlphaCalculatorMode": {
+      "type":"string",
+      "title":"AlphaCalculatorMode schema",
+      "description":"Specifies which type of AlphaCalculator should be used to convert corner weights into alpha values.",
+      "enum":["Max",
+              "Linear"]
+              
     }
   },
   "required": [
@@ -187,6 +194,7 @@
     "OutputDirectory",
     "Terrains",
     "Cliques",
+    "AlphaCalculatorMode",
     "BorderOptions"
   ]
 }

--- a/Wangscape/tilegen/alpha/AlphaCalculatorMode.h
+++ b/Wangscape/tilegen/alpha/AlphaCalculatorMode.h
@@ -1,0 +1,15 @@
+#pragma once
+
+namespace tilegen
+{
+namespace alpha
+{
+
+enum class AlphaCalculatorMode
+{
+    Max,
+    Linear
+};
+
+} // namespace alpha
+} // namespace tilegen

--- a/Wangscape/tilegen/alpha/CMakeLists.txt
+++ b/Wangscape/tilegen/alpha/CMakeLists.txt
@@ -1,7 +1,7 @@
 set(tilegen-alpha-src
-    ${CMAKE_CURRENT_SOURCE_DIR}/AlphaCalculatorBase.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/AlphaCalculatorLinear.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/AlphaCalculatorMax.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/CalculatorBase.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/CalculatorLinear.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/CalculatorMax.cpp
 )
 
 set(tilegen-src

--- a/Wangscape/tilegen/alpha/CalculatorBase.cpp
+++ b/Wangscape/tilegen/alpha/CalculatorBase.cpp
@@ -1,4 +1,4 @@
-#include "AlphaCalculatorBase.h"
+#include "CalculatorBase.h"
 #include <algorithm>
 #include "common.h"
 
@@ -7,29 +7,29 @@ namespace tilegen
 namespace alpha
 {
 
-AlphaCalculatorBase::AlphaCalculatorBase():
+CalculatorBase::CalculatorBase():
     mAlphas((int)CORNERS)
 {
     zeroAlphas();
 }
 
-void AlphaCalculatorBase::zeroAlphas()
+void CalculatorBase::zeroAlphas()
 {
     for (auto& alpha : mAlphas)
         alpha = 0;
 }
 
-sf::Uint8 & AlphaCalculatorBase::getAlpha(size_t index)
+sf::Uint8 & CalculatorBase::getAlpha(size_t index)
 {
     return mAlphas[index];
 }
 
-const AlphaCalculatorBase::Alphas & AlphaCalculatorBase::getAlphas() const
+const CalculatorBase::Alphas & CalculatorBase::getAlphas() const
 {
     return mAlphas;
 }
 
-void AlphaCalculatorBase::updateAlphas(const Weights & weights)
+void CalculatorBase::updateAlphas(const Weights & weights)
 {
     zeroAlphas();
     updateAlphasAux(weights);

--- a/Wangscape/tilegen/alpha/CalculatorBase.h
+++ b/Wangscape/tilegen/alpha/CalculatorBase.h
@@ -8,19 +8,19 @@ namespace tilegen
 namespace alpha
 {
 
-class AlphaCalculatorBase
+class CalculatorBase
 {
 public:
     typedef std::vector<double> Weights;
     typedef std::vector<sf::Uint8> Alphas;
 
-    AlphaCalculatorBase();
-    virtual ~AlphaCalculatorBase() = default;
+    CalculatorBase();
+    virtual ~CalculatorBase() = default;
 
     void updateAlphas(const Weights& weights);
     const Alphas& getAlphas() const;
 protected:
-    // Implement this method to define a new AlphaCalculator.
+    // Implement this method to define a new Calculator.
     // The method must set values in mAlphas which sum to 255.
     // The method must not change the length of mAlphas.
     virtual void updateAlphasAux(const Weights& weights) = 0;

--- a/Wangscape/tilegen/alpha/CalculatorLinear.cpp
+++ b/Wangscape/tilegen/alpha/CalculatorLinear.cpp
@@ -1,4 +1,4 @@
-#include "AlphaCalculatorLinear.h"
+#include "CalculatorLinear.h"
 #include <algorithm>
 #include <assert.h>
 #include <numeric>
@@ -8,7 +8,7 @@ namespace tilegen
 namespace alpha
 {
 
-void AlphaCalculatorLinear::updateAlphasAux(const Weights& weights)
+void CalculatorLinear::updateAlphasAux(const Weights& weights)
 {
     int alpha_remaining = 255;
     double total_weight = std::accumulate(weights.cbegin(), weights.cend(), 0.);

--- a/Wangscape/tilegen/alpha/CalculatorLinear.h
+++ b/Wangscape/tilegen/alpha/CalculatorLinear.h
@@ -1,15 +1,15 @@
 #pragma once
-#include "AlphaCalculatorBase.h"
+#include "CalculatorBase.h"
 
 namespace tilegen
 {
 namespace alpha
 {
 
-class AlphaCalculatorLinear : public AlphaCalculatorBase
+class CalculatorLinear : public CalculatorBase
 {
 protected:
-    // This AlphaCalculator class requires input weights
+    // This Calculator class requires input weights
     // to be all nonnegative,
     // and to have a sum significantly reater than 0.
     // If these conditions are not satisfied,

--- a/Wangscape/tilegen/alpha/CalculatorMax.cpp
+++ b/Wangscape/tilegen/alpha/CalculatorMax.cpp
@@ -1,4 +1,4 @@
-#include "AlphaCalculatorMax.h"
+#include "CalculatorMax.h"
 #include <algorithm>
 
 namespace tilegen
@@ -6,7 +6,7 @@ namespace tilegen
 namespace alpha
 {
 
-void AlphaCalculatorMax::updateAlphasAux(const Weights& weights)
+void CalculatorMax::updateAlphasAux(const Weights& weights)
 {
     auto max_it = std::max_element(weights.cbegin(), weights.cend());
     auto max_index = std::distance(weights.cbegin(), max_it);

--- a/Wangscape/tilegen/alpha/CalculatorMax.h
+++ b/Wangscape/tilegen/alpha/CalculatorMax.h
@@ -1,12 +1,12 @@
 #pragma once
-#include "AlphaCalculatorBase.h"
+#include "CalculatorBase.h"
 
 namespace tilegen
 {
 namespace alpha
 {
 
-class AlphaCalculatorMax : public AlphaCalculatorBase
+class CalculatorMax : public CalculatorBase
 {
 protected:
     virtual void updateAlphasAux(const Weights& weights);

--- a/Wangscape/tilegen/alpha/CalculatorMode.h
+++ b/Wangscape/tilegen/alpha/CalculatorMode.h
@@ -5,7 +5,7 @@ namespace tilegen
 namespace alpha
 {
 
-enum class AlphaCalculatorMode
+enum class CalculatorMode
 {
     Max,
     Linear

--- a/Wangscape/tilegen/partition/TilePartitionerGradient.cpp
+++ b/Wangscape/tilegen/partition/TilePartitionerGradient.cpp
@@ -1,5 +1,5 @@
 #include "TilePartitionerGradient.h"
-#include "tilegen/alpha/AlphaCalculatorLinear.h"
+#include "tilegen/alpha/CalculatorLinear.h"
 #include <utility>
 
 namespace tilegen
@@ -28,7 +28,7 @@ void TilePartitionerGradient::makePartition(TilePartition & regions,
     std::vector<double> weights(corners.size(), 0.);
     const int resolution_sub_1 = mOptions.tileFormat.resolution - 1;
     const int quarter_res = mOptions.tileFormat.resolution / 4;
-    alpha::AlphaCalculatorLinear ac;
+    alpha::CalculatorLinear ac;
     for (size_t x = 0; x < mOptions.tileFormat.resolution; x++)
     {
         for (size_t y = 0; y < mOptions.tileFormat.resolution; y++)

--- a/Wangscape/tilegen/partition/TilePartitionerPerlin.cpp
+++ b/Wangscape/tilegen/partition/TilePartitionerPerlin.cpp
@@ -2,8 +2,8 @@
 #include "noise/module/ModuleFactories.h"
 #include "noise/RasterValues.h"
 #include "noise/module/Pow.h"
-#include "tilegen/alpha/AlphaCalculatorMax.h"
-#include "tilegen/alpha/AlphaCalculatorLinear.h"
+#include "tilegen/alpha/CalculatorMax.h"
+#include "tilegen/alpha/CalculatorLinear.h"
 
 namespace tilegen
 {
@@ -39,17 +39,17 @@ void TilePartitionerPerlin::noiseToAlpha(std::vector<noise::RasterValues<double>
                                          size_t resolution) const
 {
     std::vector<double> weights((int)CORNERS);
-    std::unique_ptr<alpha::AlphaCalculatorBase> ac;
-    switch (mOptions.alphaCalculatorMode)
+    std::unique_ptr<alpha::CalculatorBase> ac;
+    switch (mOptions.CalculatorMode)
     {
-    case alpha::AlphaCalculatorMode::Max:
-        ac = std::make_unique<alpha::AlphaCalculatorMax>();
+    case alpha::CalculatorMode::Max:
+        ac = std::make_unique<alpha::CalculatorMax>();
         break;
-    case alpha::AlphaCalculatorMode::Linear:
-        ac = std::make_unique<alpha::AlphaCalculatorLinear>();
+    case alpha::CalculatorMode::Linear:
+        ac = std::make_unique<alpha::CalculatorLinear>();
         break;
     default:
-        throw std::runtime_error("Invalid AlphaCalculatorMode");
+        throw std::runtime_error("Invalid CalculatorMode");
     }
     for (size_t x = 0; x < resolution; x++)
     {


### PR DESCRIPTION
Resolves #76.
* Print details of JSON decode errors to stdout.
* Make an enum for AlphaCalculator classes.
* Add a data member to Options class.
* Add a required field in Options codec (with a complex enum codec; this can be moved into a separate file if necessary).
* Add required fields to example JSON options.
* Use `Options::AlphaCalculatorMode` to choose `AlphaCalculator` subclass in `TilePartitionerPerlin` (not `Gradient` or `Squares`.

All tests pass, example tilesets are generated as expected (`example` with `AlphaCalculatorMax`, `example3` with `AlphaCalculatorLinear`).