### PR TITLE
Unabbreviate metaOutput instances

### DIFF
--- a/Wangscape/Main.cpp
+++ b/Wangscape/Main.cpp
@@ -74,7 +74,7 @@ int main(int argc, char** argv)
         if (!output.copyToImage().saveToFile(filename))
             throw std::runtime_error("Couldn't write image");
     });
-    tg.mo.writeAll(optionsManager.getOptions());
+    tg.metaOutput.writeAll(optionsManager.getOptions());
 
     return 0;
 }

--- a/Wangscape/tilegen/TilesetGenerator.cpp
+++ b/Wangscape/tilegen/TilesetGenerator.cpp
@@ -26,7 +26,7 @@ TilesetGenerator::TilesetGenerator(const Options& options,
 
 void TilesetGenerator::generate(std::function<void(const sf::Texture&, std::string)> callback)
 {
-    mo.setResolution(options.tileFormat.resolution);
+    metaOutput.setResolution(options.tileFormat.resolution);
     boost::filesystem::path p(options.relativeOutputDirectory);
     for (const auto& clique : options.cliques)
     {
@@ -39,7 +39,7 @@ void TilesetGenerator::generate(std::function<void(const sf::Texture&, std::stri
 
         // MetaOutput.addTileset, addTile should use this version of filename;
         // relative to output dir, not options dir!
-        mo.addTileset(clique, filename, res_x, res_y);
+        metaOutput.addTileset(clique, filename, res_x, res_y);
         generateClique(clique, *output, filename);
         output->display();
 
@@ -64,7 +64,7 @@ void TilesetGenerator::generateClique(const Options::Clique& clique, sf::RenderT
             z += corner_clique_indices[i];
         }
         TileGenerator::generate(image, x, y, corner_terrains, images, options, *mTilePartitioner.get());
-        mo.addTile(corner_terrains, filename, x*options.tileFormat.resolution, y*options.tileFormat.resolution);
+        metaOutput.addTile(corner_terrains, filename, x*options.tileFormat.resolution, y*options.tileFormat.resolution);
         stop = true;
         auto zip_begin = boost::make_zip_iterator(boost::make_tuple(corner_terrains.begin(),
                                                                     corner_clique_indices.begin()));

--- a/Wangscape/tilegen/TilesetGenerator.h
+++ b/Wangscape/tilegen/TilesetGenerator.h
@@ -19,7 +19,7 @@ public:
     void generate(std::function<void(const sf::Texture&, std::string)> callback);
     void generateClique(const Options::Clique& clique, sf::RenderTexture& image, std::string filename);
     const Options& options;
-    metaoutput::MetaOutput mo;
+    metaoutput::MetaOutput metaOutput;
     TerrainImages images;
 private:
     std::unique_ptr<tilegen::partition::TilePartitionerBase> mTilePartitioner;

--- a/WangscapeTest/TestMetaOutput.cpp
+++ b/WangscapeTest/TestMetaOutput.cpp
@@ -19,12 +19,12 @@ class TestMetaOutput : public TestRequiringOptions
 protected:
     using TestRequiringOptions::TestRequiringOptions;
     tilegen::TilesetGenerator tg;
-    const metaoutput::MetaOutput& mo;
+    const metaoutput::MetaOutput& metaOutput;
     TestMetaOutput() :
         TestRequiringOptions(),
         tg(options,
            std::move(std::make_unique<tilegen::partition::TilePartitionerSquares>(options))),
-        mo(tg.mo)
+        metaOutput(tg.metaOutput)
     {
         tg.generate([&](const sf::Texture& output, std::string filename) {});
     };
@@ -34,7 +34,7 @@ protected:
 // TODO replace this test with something faster
 TEST_F(TestMetaOutput, TestMetaOutputCorrect)
 {
-    const auto& td = mo.getTileData();
+    const auto& td = metaOutput.getTileData();
     for (const auto& corner : td[0].corners)
     {
         EXPECT_EQ(corner, "g") << "Incorrect terrain id in TileData[0].corners";
@@ -45,17 +45,17 @@ TEST_F(TestMetaOutput, TestMetaOutputCorrect)
         EXPECT_EQ(corner, "s") << "Incorrect terrain id in TileData[15].corners";
     }
 
-    const auto& tsd = mo.getTilesetData();
+    const auto& tsd = metaOutput.getTilesetData();
     EXPECT_TRUE(std::any_of(std::cbegin(tsd), std::cend(tsd),
                 [](auto& t){return t.filename == "g.s.png";}));
     EXPECT_TRUE(std::all_of(std::begin(tsd), std::end(tsd),
                 [](auto& t){return t.resolution == 32;})) << "Incorrect resolution";
 
-    const auto& tgd = mo.getTileGroups();
+    const auto& tgd = metaOutput.getTileGroups();
     EXPECT_TRUE(tgd.find("g.s.g.s") != tgd.end()) << "TileGroups is missing ""g.s.g.s""";
     EXPECT_TRUE(tgd.find("g.s.s.g") != tgd.end()) << "TileGroups is missing ""g.s.s.g""";
 
-    const auto& ta = mo.getTerrainHypergraph();
+    const auto& ta = metaOutput.getTerrainHypergraph();
     EXPECT_NE(ta.find("g"), ta.end()) << R"("TerrainHypergraph is missing "g")";
     auto it = ta.at("g").cbegin();
     EXPECT_NE(std::find((*it).cbegin(), (*it).cend(), "s"), (*it).cend());


### PR DESCRIPTION
Other data members named after their class name are `ClassName className` or `ClassName mClassName`. `MetaOutput` data members should be `metaOutput`, not `mo`.