### PR TITLE
Top left border modules (and significant bugfixes)

### DIFF
--- a/Wangscape/Options.h
+++ b/Wangscape/Options.h
@@ -31,8 +31,8 @@ public:
     std::string combinerModuleGroup;
     boost::optional<std::string> defaultModuleGroup;
     std::vector<TerrainModuleGroupLocation> centralModuleGroups;
-    std::vector<BorderModuleGroupLocation> horizontalBorderModuleGroups;
-    std::vector<BorderModuleGroupLocation> verticalBorderModuleGroups;
+    std::vector<BorderModuleGroupLocation> leftBorderModuleGroups;
+    std::vector<BorderModuleGroupLocation> topBorderModuleGroups;
     bool debugOutput;
     
     virtual ~Options() = default;

--- a/Wangscape/codecs/OptionsCodec.h
+++ b/Wangscape/codecs/OptionsCodec.h
@@ -33,8 +33,8 @@ struct default_codec_t<Options>
         codec.required("CombinerModuleGroup", &Options::combinerModuleGroup);
         codec.optional("DefaultModuleGroup", &Options::defaultModuleGroup);
         codec.optional("CentralModuleGroups", &Options::centralModuleGroups);
-        codec.optional("HorizontalBorderModuleGroups", &Options::horizontalBorderModuleGroups);
-        codec.optional("VerticalBorderModuleGroups", &Options::verticalBorderModuleGroups);
+        codec.optional("LeftBorderModuleGroups", &Options::leftBorderModuleGroups);
+        codec.optional("TopBorderModuleGroups", &Options::topBorderModuleGroups);
         codec.required("DebugOutput", &Options::debugOutput);
         return codec;
     }

--- a/Wangscape/noise/ModuleGroup.cpp
+++ b/Wangscape/noise/ModuleGroup.cpp
@@ -48,4 +48,14 @@ const std::map<ModuleID, module::ModulePtr>& ModuleGroup::getModules() const
     return mModules;
 }
 
+std::shared_ptr<ModuleGroup> ModuleGroup::makeConstModuleGroup(double const_value)
+{
+    auto result = std::make_shared<ModuleGroup>();
+    auto module = std::make_shared<module::Wrapper<module::Const>>();
+    module->module->SetConstValue(const_value);
+    result->mModules["OUTPUT"] = module;
+    result->mOutputModule = "OUTPUT";
+    return result;
+}
+
 } // namespace noise

--- a/Wangscape/noise/ModuleGroup.h
+++ b/Wangscape/noise/ModuleGroup.h
@@ -27,6 +27,7 @@ public:
     const module::ModulePtr getOutputModule() const;
     void setInputModuleSource(size_t index, module::ModulePtr source_module);
     const std::map<ModuleID, module::ModulePtr>& getModules() const;
+    static std::shared_ptr<ModuleGroup> makeConstModuleGroup(double const_value);
 private:
     friend class EncodedModuleGroup;
     //template<> 

--- a/Wangscape/noise/ModuleManager.cpp
+++ b/Wangscape/noise/ModuleManager.cpp
@@ -16,6 +16,8 @@ namespace noise {
 ModuleManager::ModuleManager(const Options & options) :
     mRNG((unsigned int)time(nullptr))
 {
+    mBottomRightBorder = ModuleGroup::makeConstModuleGroup(0.0);
+
     boost::filesystem::path p(options.directory);
 
     p /= options.combinerModuleGroup;
@@ -31,20 +33,20 @@ ModuleManager::ModuleManager(const Options & options) :
         if (!inserted.second)
             throw std::runtime_error("Tried to load two central module groups with the same terrain");
     }
-    for (auto it : options.horizontalBorderModuleGroups)
+    for (auto it : options.leftBorderModuleGroups)
     {
         p /= it.filename;
-        auto inserted = mHorizontalBorders.insert({it.terrains, loadModuleGroup(p.string())});
+        auto inserted = mLeftBorders.insert({it.terrains, loadModuleGroup(p.string())});
         p.remove_filename();
 
         if (!inserted.second)
             throw std::runtime_error("Tried to load two horizontal border module groups with the same terrain pair");
         inserted.first->second->setSeeds(mRNG());
     }
-    for (auto it : options.verticalBorderModuleGroups)
+    for (auto it : options.topBorderModuleGroups)
     {
         p /= it.filename;
-        auto inserted = mVerticalBorders.insert({it.terrains, loadModuleGroup(p.string())});
+        auto inserted = mTopBorders.insert({it.terrains, loadModuleGroup(p.string())});
         p.remove_filename();
 
         if (!inserted.second)
@@ -72,33 +74,38 @@ ModuleManager::ModuleManager(const Options & options) :
             for (const auto& t2 : clique)
             {
                 TerrainIDPair tp{t1, t2};
-                if (mHorizontalBorders.find(tp) == mHorizontalBorders.end())
+                if (mLeftBorders.find(tp) == mLeftBorders.end())
                 {
                     if (options.defaultModuleGroup)
-                        mHorizontalBorders.insert({tp, loadModuleGroup(p.string())});
+                        mLeftBorders.insert({tp, loadModuleGroup(p.string())});
                     else
-                        throw std::runtime_error("Missing vertical module group, and no default module group");
+                        throw std::runtime_error("Missing left border module group, and no default module group");
                 }
-                if (mVerticalBorders.find(tp) == mVerticalBorders.end())
+                if (mTopBorders.find(tp) == mTopBorders.end())
                 {
                     if(options.defaultModuleGroup)
-                        mVerticalBorders.insert({tp, loadModuleGroup(p.string())});
+                        mTopBorders.insert({tp, loadModuleGroup(p.string())});
                     else
-                        throw std::runtime_error("Missing vertical module group, and no default module group");
+                        throw std::runtime_error("Missing top border module group, and no default module group");
                 }
             }
     }
     
 }
 
-ModuleGroup& ModuleManager::getVerticalBorder(TerrainID top, TerrainID bottom)
+ModuleGroup& ModuleManager::getTopBorder(TerrainID top, TerrainID bottom)
 {
-    return *mVerticalBorders.at({top, bottom});
+    return *mTopBorders.at({top, bottom});
 }
 
-ModuleGroup& ModuleManager::getHorizontalBorder(TerrainID left, TerrainID right)
+ModuleGroup& ModuleManager::getLeftBorder(TerrainID left, TerrainID right)
 {
-    return *mHorizontalBorders.at({left, right});
+    return *mLeftBorders.at({left, right});
+}
+
+ModuleGroup & ModuleManager::getBottomRightBorder()
+{
+    return *mBottomRightBorder;
 }
 
 ModuleGroup& ModuleManager::getCentral(TerrainID terrain)

--- a/Wangscape/noise/ModuleManager.cpp
+++ b/Wangscape/noise/ModuleManager.cpp
@@ -40,7 +40,7 @@ ModuleManager::ModuleManager(const Options & options) :
         p.remove_filename();
 
         if (!inserted.second)
-            throw std::runtime_error("Tried to load two horizontal border module groups with the same terrain pair");
+            throw std::runtime_error("Tried to load two left border module groups with the same terrain pair");
         inserted.first->second->setSeeds(mRNG());
     }
     for (auto it : options.topBorderModuleGroups)
@@ -50,7 +50,7 @@ ModuleManager::ModuleManager(const Options & options) :
         p.remove_filename();
 
         if (!inserted.second)
-            throw std::runtime_error("Tried to load two vertical border module groups with the same terrain pair");
+            throw std::runtime_error("Tried to load two top border module groups with the same terrain pair");
         inserted.first->second->setSeeds(mRNG());
     }
     if (options.defaultModuleGroup)
@@ -77,14 +77,20 @@ ModuleManager::ModuleManager(const Options & options) :
                 if (mLeftBorders.find(tp) == mLeftBorders.end())
                 {
                     if (options.defaultModuleGroup)
-                        mLeftBorders.insert({tp, loadModuleGroup(p.string())});
+                    {
+                        auto inserted = mLeftBorders.insert({tp, loadModuleGroup(p.string())});
+                        inserted.first->second->setSeeds(mRNG());
+                    }
                     else
                         throw std::runtime_error("Missing left border module group, and no default module group");
                 }
                 if (mTopBorders.find(tp) == mTopBorders.end())
                 {
-                    if(options.defaultModuleGroup)
-                        mTopBorders.insert({tp, loadModuleGroup(p.string())});
+                    if (options.defaultModuleGroup)
+                    {
+                        auto inserted = mTopBorders.insert({tp, loadModuleGroup(p.string())});
+                        inserted.first->second->setSeeds(mRNG());
+                    }
                     else
                         throw std::runtime_error("Missing top border module group, and no default module group");
                 }

--- a/Wangscape/noise/ModuleManager.h
+++ b/Wangscape/noise/ModuleManager.h
@@ -19,8 +19,9 @@ public:
     explicit ModuleManager(const Options& options);
     virtual ~ModuleManager() = default;
 
-    ModuleGroup& getVerticalBorder(TerrainID top, TerrainID bottom);
-    ModuleGroup& getHorizontalBorder(TerrainID left, TerrainID right);
+    ModuleGroup& getTopBorder(TerrainID top, TerrainID bottom);
+    ModuleGroup& getLeftBorder(TerrainID left, TerrainID right);
+    ModuleGroup& getBottomRightBorder();
     ModuleGroup& getCentral(TerrainID terrain);
     ModuleGroup& getCombiner();
 private:
@@ -31,20 +32,22 @@ private:
     // Evaluated in the square [0,1]x[0,1] (if the corners are at the bottom)
     // or [0,1]x[-1,0] (if the corners are at the top).
     // Reseeding will make terrain borders incompatible.
-    std::map<TerrainIDPair, std::shared_ptr<ModuleGroup>> mHorizontalBorders;
+    std::map<TerrainIDPair, std::shared_ptr<ModuleGroup>> mLeftBorders;
 
     // User-defined masks specifying how two corner terrain types
     // should blend in the region of a vertical border.
     // Evaluated in the square [0,1]x[0,1] (if the corners are on the right)
     // or [-1,0]x[0,1] (if the corners are on the left).
     // Reseeding will make terrain borders incompatible.
-    std::map<TerrainIDPair, std::shared_ptr<ModuleGroup>> mVerticalBorders;
+    std::map<TerrainIDPair, std::shared_ptr<ModuleGroup>> mTopBorders;
 
     // User-defined masks specifying how a corner terrain type
     // should blend with other corners in the region of the centre of the tile.
     // Evaluated in the square [0,1]x[0,1].
     // Normally evaluated with a different seed in every corner of every tile.
     std::map<TerrainID, std::shared_ptr<ModuleGroup>> mCentres;
+
+    std::shared_ptr<ModuleGroup> mBottomRightBorder;
 
     std::shared_ptr<ModuleGroup> mCombiner;
 };

--- a/Wangscape/tilegen/partition/TilePartitionerNoise.cpp
+++ b/Wangscape/tilegen/partition/TilePartitionerNoise.cpp
@@ -21,10 +21,16 @@ noise::module::ModulePtr TilePartitionerNoise::makeCornerModule(const Corners& c
 
     noise::ModuleGroup& combiner = mNoiseModuleManager.getCombiner();
     noise::ModuleGroup& central = mNoiseModuleManager.getCentral(corner_id);
-    noise::ModuleGroup& border_h = mNoiseModuleManager.getHorizontalBorder(left ? corner_id : corner_h,
-                                                                           left ? corner_h : corner_id);
-    noise::ModuleGroup& border_v = mNoiseModuleManager.getVerticalBorder(top ? corner_id : corner_v,
-                                                                         top ? corner_v : corner_id);
+    noise::ModuleGroup& border_h = 
+        left
+        ? mNoiseModuleManager.getLeftBorder(left ? corner_id : corner_h,
+                                            left ? corner_h : corner_id)
+        : mNoiseModuleManager.getBottomRightBorder();
+    noise::ModuleGroup& border_v =
+        top
+        ? mNoiseModuleManager.getTopBorder(top ? corner_id : corner_v,
+                                           top ? corner_v : corner_id)
+        : mNoiseModuleManager.getBottomRightBorder();
     central.setQuadrant(left, top, false);
     border_h.setQuadrant(left, top, false);
     border_v.setQuadrant(left, top, false);

--- a/Wangscape/tilegen/partition/TilePartitionerNoise.cpp
+++ b/Wangscape/tilegen/partition/TilePartitionerNoise.cpp
@@ -15,9 +15,9 @@ namespace partition
 noise::module::ModulePtr TilePartitionerNoise::makeCornerModule(const Corners& corners,
                                                                 bool left, bool top)
 {
-    TerrainID corner_id = corners[ (left ? 0 : 1) +  (top ? 0 : 2)];
-    TerrainID corner_h =  corners[(!left ? 0 : 1) +  (top ? 0 : 2)];
-    TerrainID corner_v =  corners[ (left ? 0 : 1) + (!top ? 0 : 2)];
+    TerrainID corner_id = corners[ (left ? 0 : 2) +  (top ? 0 : 1)];
+    TerrainID corner_h =  corners[(!left ? 0 : 2) +  (top ? 0 : 1)];
+    TerrainID corner_v =  corners[ (left ? 0 : 2) + (!top ? 0 : 1)];
 
     noise::ModuleGroup& combiner = mNoiseModuleManager.getCombiner();
     noise::ModuleGroup& central = mNoiseModuleManager.getCentral(corner_id);

--- a/doc/examples/example2/example_options.json
+++ b/doc/examples/example2/example_options.json
@@ -31,7 +31,8 @@
     ]
   ],
   "AlphaCalculatorMode":"Max",
-  "HorizontalBorderModuleGroups": [
+  "DefaultModuleGroup": "default_module_group.json",
+  "LeftBorderModuleGroups": [
     {
       "Terrains":["g","g"],
       "Filename":"default_module_group.json"
@@ -49,7 +50,7 @@
       "Filename":"default_module_group.json"
     }
   ],
-  "VerticalBorderModuleGroups": [
+  "TopBorderModuleGroups": [
     {
       "Terrains":["g","s"],
       "Filename":"default_module_group.json"

--- a/doc/examples/example3/example_options.json
+++ b/doc/examples/example3/example_options.json
@@ -46,7 +46,7 @@
   ],
   "AlphaCalculatorMode":"Linear",
   "DefaultModuleGroup":"default_module_group.json",
-  "HorizontalBorderModuleGroups": [
+  "LeftBorderModuleGroups": [
     {
       "Terrains":["s","g"],
       "Filename":"special_module_group.json"
@@ -56,7 +56,7 @@
       "Filename":"special_module_group.json"
     }
   ],
-  "VerticalBorderModuleGroups": [
+  "TopBorderModuleGroups": [
     {
       "Terrains":["s","g"],
       "Filename":"special_module_group.json"

--- a/doc/schemas/module_group_schema.json
+++ b/doc/schemas/module_group_schema.json
@@ -125,8 +125,8 @@
     },
     "abs": {
       "type": "object",
-      "title": "ModuleGroup module schema",
-      "description": "Specifies a Abs module and its attributes.",
+      "title": "Abs module schema",
+      "description": "Specifies an Abs module and its attributes.",
       "additionalProperties":false,
       "properties":{
         "type":{
@@ -146,8 +146,8 @@
     },
     "add": {
       "type": "object",
-      "title": "ModuleGroup module schema",
-      "description": "Specifies a Add module and its attributes.",
+      "title": "Add module schema",
+      "description": "Specifies an Add module and its attributes.",
       "additionalProperties":false,
       "properties":{
         "type":{
@@ -167,7 +167,7 @@
     },
     "billow": {
       "type": "object",
-      "title": "ModuleGroup module schema",
+      "title": "Billow module schema",
       "description": "Specifies a Billow module and its attributes.",
       "additionalProperties":false,
       "properties":{
@@ -215,7 +215,7 @@
     },
     "blend": {
       "type": "object",
-      "title": "ModuleGroup module schema",
+      "title": "Blend module schema",
       "description": "Specifies a Blend module and its attributes.",
       "additionalProperties":false,
       "properties":{
@@ -242,7 +242,7 @@
     },
     "cache": {
       "type": "object",
-      "title": "ModuleGroup module schema",
+      "title": "Cache module schema",
       "description": "Specifies a Cache module and its attributes.",
       "additionalProperties":false,
       "properties":{
@@ -263,7 +263,7 @@
     },
     "checkerboard": {
       "type": "object",
-      "title": "ModuleGroup module schema",
+      "title": "Checkerboard module schema",
       "description": "Specifies a Checkerboard module and its attributes.",
       "additionalProperties":false,
       "properties":{
@@ -280,7 +280,7 @@
     },
     "clamp": {
       "type": "object",
-      "title": "ModuleGroup module schema",
+      "title": "Clamp module schema",
       "description": "Specifies a Clamp module and its attributes.",
       "additionalProperties":false,
       "properties":{
@@ -311,7 +311,7 @@
     },
     "const": {
       "type": "object",
-      "title": "ModuleGroup module schema",
+      "title": "Const module schema",
       "description": "Specifies a Const module and its attributes.",
       "additionalProperties":false,
       "properties":{
@@ -333,7 +333,7 @@
     },
     "corner_combiner_base": {
       "type": "object",
-      "title": "ModuleGroup module schema",
+      "title": "CornerCombinerBase module schema",
       "description": "Specifies a CornerCombinerBase module and its attributes.",
       "additionalProperties":false,
       "properties":{
@@ -355,7 +355,7 @@
     },
     "curve": {
       "type": "object",
-      "title": "ModuleGroup module schema",
+      "title": "Curve module schema",
       "description": "Specifies a Curve module and its attributes.",
       "additionalProperties":false,
       "properties":{
@@ -393,7 +393,7 @@
     },
     "cylinders": {
       "type": "object",
-      "title": "ModuleGroup module schema",
+      "title": "Cylinders module schema",
       "description": "Specifies a Cylinders module and its attributes.",
       "additionalProperties":false,
       "properties":{
@@ -415,7 +415,7 @@
     },
     "displace": {
       "type": "object",
-      "title": "ModuleGroup module schema",
+      "title": "Displace module schema",
       "description": "Specifies a Displace module and its attributes.",
       "additionalProperties":false,
       "properties":{
@@ -485,8 +485,8 @@
     },
     "exponent": {
       "type": "object",
-      "title": "ModuleGroup module schema",
-      "description": "Specifies a Exponent module and its attributes.",
+      "title": "Exponent module schema",
+      "description": "Specifies an Exponent module and its attributes.",
       "additionalProperties":false,
       "properties":{
         "type":{
@@ -511,8 +511,8 @@
     },
     "exp": {
       "type": "object",
-      "title": "ModuleGroup module schema",
-      "description": "Specifies a Exp module and its attributes.",
+      "title": "Exp module schema",
+      "description": "Specifies an Exp module and its attributes.",
       "additionalProperties":false,
       "properties":{
         "type":{
@@ -537,7 +537,7 @@
     },
     "forward": {
       "type": "object",
-      "title": "ModuleGroup module schema",
+      "title": "Forward module schema",
       "description": "Specifies a Forward module and its attributes.",
       "additionalProperties":false,
       "properties":{
@@ -557,7 +557,7 @@
     },
     "gradient_x": {
       "type": "object",
-      "title": "ModuleGroup module schema",
+      "title": "GradientX module schema",
       "description": "Specifies a GradientX module and its attributes.",
       "additionalProperties":false,
       "properties":{
@@ -574,7 +574,7 @@
     },
     "gradient_y": {
       "type": "object",
-      "title": "ModuleGroup module schema",
+      "title": "GradientY module schema",
       "description": "Specifies a GradientY module and its attributes.",
       "additionalProperties":false,
       "properties":{
@@ -591,7 +591,7 @@
     },
     "gradient_z": {
       "type": "object",
-      "title": "ModuleGroup module schema",
+      "title": "GradientZ module schema",
       "description": "Specifies a GradientZ module and its attributes.",
       "additionalProperties":false,
       "properties":{
@@ -608,8 +608,8 @@
     },
     "invert": {
       "type": "object",
-      "title": "ModuleGroup module schema",
-      "description": "Specifies a Invert module and its attributes.",
+      "title": "Invert module schema",
+      "description": "Specifies an Invert module and its attributes.",
       "additionalProperties":false,
       "properties":{
         "type":{
@@ -629,7 +629,7 @@
     },
     "max": {
       "type": "object",
-      "title": "ModuleGroup module schema",
+      "title": "Max module schema",
       "description": "Specifies a Max module and its attributes.",
       "additionalProperties":false,
       "properties":{
@@ -650,7 +650,7 @@
     },
     "min": {
       "type": "object",
-      "title": "ModuleGroup module schema",
+      "title": "Min module schema",
       "description": "Specifies a Min module and its attributes.",
       "additionalProperties":false,
       "properties":{
@@ -671,7 +671,7 @@
     },
     "multiply": {
       "type": "object",
-      "title": "ModuleGroup module schema",
+      "title": "Multiply module schema",
       "description": "Specifies a Multiply module and its attributes.",
       "additionalProperties":false,
       "properties":{
@@ -692,7 +692,7 @@
     },
     "norm_lp_q": {
       "type": "object",
-      "title": "ModuleGroup module schema",
+      "title": "NormLPQ module schema",
       "description": "Specifies a NormLPQ module and its attributes.",
       "additionalProperties":false,
       "properties":{
@@ -719,7 +719,7 @@
     },
     "perlin": {
       "type": "object",
-      "title": "ModuleGroup module schema",
+      "title": "Perlin module schema",
       "description": "Specifies a Perlin module and its attributes.",
       "additionalProperties":false,
       "properties":{
@@ -767,7 +767,7 @@
     },
     "power": {
       "type": "object",
-      "title": "ModuleGroup module schema",
+      "title": "Power module schema",
       "description": "Specifies a Power module and its attributes.",
       "additionalProperties":false,
       "properties":{
@@ -788,7 +788,7 @@
     },
     "pow": {
       "type": "object",
-      "title": "ModuleGroup module schema",
+      "title": "Pow module schema",
       "description": "Specifies a Pow module and its attributes.",
       "additionalProperties":false,
       "properties":{
@@ -814,7 +814,7 @@
     },
     "quadrant_selector": {
       "type": "object",
-      "title": "ModuleGroup module schema",
+      "title": "QuadrantSelector module schema",
       "description": "Specifies a QuadrantSelector module and its attributes.",
       "additionalProperties":false,
       "properties":{
@@ -927,7 +927,7 @@
     },
     "ridged_multi": {
       "type": "object",
-      "title": "ModuleGroup module schema",
+      "title": "RidgedMulti module schema",
       "description": "Specifies a RidgedMulti module and its attributes.",
       "additionalProperties":false,
       "properties":{
@@ -974,7 +974,7 @@
     },
     "rotate_point": {
       "type": "object",
-      "title": "ModuleGroup module schema",
+      "title": "RotatePoint module schema",
       "description": "Specifies a RotatePoint module and its attributes.",
       "additionalProperties":false,
       "properties":{
@@ -1042,7 +1042,7 @@
     },
     "scale_bias": {
       "type": "object",
-      "title": "ModuleGroup module schema",
+      "title": "ScaleBias module schema",
       "description": "Specifies a ScaleBias module and its attributes.",
       "additionalProperties":false,
       "properties":{
@@ -1073,7 +1073,7 @@
     },
     "scale_point": {
       "type": "object",
-      "title": "ModuleGroup module schema",
+      "title": "ScalePoint module schema",
       "description": "Specifies a ScalePoint module and its attributes.",
       "additionalProperties":false,
       "properties":{
@@ -1150,7 +1150,7 @@
     },
     "select": {
       "type": "object",
-      "title": "ModuleGroup module schema",
+      "title": "Select module schema",
       "description": "Specifies a Select module and its attributes.",
       "additionalProperties":false,
       "properties":{
@@ -1192,7 +1192,7 @@
     },
     "spheres": {
       "type": "object",
-      "title": "ModuleGroup module schema",
+      "title": "Spheres module schema",
       "description": "Specifies a Spheres module and its attributes.",
       "additionalProperties":false,
       "properties":{
@@ -1214,7 +1214,7 @@
     },
     "terrace": {
       "type": "object",
-      "title": "ModuleGroup module schema",
+      "title": "Terrace module schema",
       "description": "Specifies a Terrace module and its attributes.",
       "additionalProperties":false,
       "properties":{
@@ -1249,7 +1249,7 @@
     },
     "translate_point": {
       "type": "object",
-      "title": "ModuleGroup module schema",
+      "title": "TranslatePoint module schema",
       "description": "Specifies a TranslatePoint module and its attributes.",
       "additionalProperties":false,
       "properties":{
@@ -1326,7 +1326,7 @@
     },
     "turbulence": {
       "type": "object",
-      "title": "ModuleGroup module schema",
+      "title": "Turbulence module schema",
       "description": "Specifies a Turbulence module and its attributes.",
       "additionalProperties":false,
       "properties":{
@@ -1369,7 +1369,7 @@
     },
     "voronoi": {
       "type": "object",
-      "title": "ModuleGroup module schema",
+      "title": "Voronoi module schema",
       "description": "Specifies a Voronoi module and its attributes.",
       "additionalProperties":false,
       "properties":{

--- a/doc/schemas/options_schema.json
+++ b/doc/schemas/options_schema.json
@@ -163,13 +163,13 @@
     "DefaultModuleGroup": {
       "type": "string",
       "title": "DefaultModuleGroup schema",
-      "description":"Optionally specifies the location of a JSON file containing a default module group to use for tile centres and borders which don't have a module group specified in CentralModuleGroups, HorizontalBorderModuleGroups, or VerticalBorderModuleGroups.",
+      "description":"Optionally specifies the location of a JSON file containing a default module group to use for tile centres and borders which don't have a module group specified in CentralModuleGroups, LeftBorderModuleGroups, or RightBorderModuleGroups.",
       "minLength":1
     },
-    "HorizontalBorderModuleGroups": {
+    "LeftBorderModuleGroups": {
       "type": "array",
-      "title":"HorizontalBorderModuleGroup schema",
-      "description":"Specifies the locations of JSON files containing module groups to use along horizontal borders in tile generation.",
+      "title":"LeftBorderModuleGroup schema",
+      "description":"Specifies the locations of JSON files containing module groups to use to weight the left side of horizontal borders in tile generation.",
       "uniqueItems": true,
       "minItems":1,
       "items": {
@@ -205,10 +205,10 @@
         "additionalProperties":false
       }
     },
-    "VerticalBorderModuleGroups": {
+    "TopBorderModuleGroups": {
       "type": "array",
-      "title":"VerticalBorderModuleGroup schema",
-      "description":"Specifies the locations of JSON files containing module groups to use along vertical borders in tile generation.",
+      "title":"TopBorderModuleGroup schema",
+      "description":"Specifies the locations of JSON files containing module groups to use to weight the top side of vertical borders in tile generation.",
       "uniqueItems": true,
       "minItems": 1,
       "items": {


### PR DESCRIPTION
Branched from #83. Implements option 8 in #52. Also fixed two significant bugs:
* Default border modules were not reseeded on load.
* `TilePartitionerNoise` used inconsistent corner numberings in `makePartition` and `makeCornerModule`.