### PR TITLE
Add CONTRIBUTING.md and related files

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,80 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, gender identity and expression, level of experience,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at `wangscape-team@googlegroups.com`,
+which is a shared inbox. If the complaint involves someone who receives that
+shared inbox, you can contact an individual maintainer.
+Currently the recipients of the inbox and their email addresses are:
+* [@serin-delaunay](https://github.com/serin-delaunay); to contact, remove all punctuation from the Github username and add `@gmail.com`.
+* Further members pending.
+
+All complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at [http://contributor-covenant.org/version/1/4][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/4/

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -60,7 +60,7 @@ which is a shared inbox. If the complaint involves someone who receives that
 shared inbox, you can contact an individual maintainer.
 Currently the recipients of the inbox and their email addresses are:
 * [@serin-delaunay](https://github.com/serin-delaunay); to contact, remove all punctuation from the Github username and add `@gmail.com`.
-* Further members pending.
+* [@hryniuk](https://github.com/hryniuk); to contact, email `lukasz.hryniuk[at]wp.pl`.
 
 All complaints will be reviewed and investigated and will result in a response that
 is deemed necessary and appropriate to the circumstances. The project team is

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,95 @@
+# Contributing to Wangscape
+
+Thanks for considering contributing to Wangscape! We're eager to include more
+people in the development process, and your help could make it easier for
+people to generate beautiful seamless tilesets for games and other applications.
+
+The following guide will help you figure out where you can best be helpful, and
+help you make contributions that we can easily integrate into the project.
+
+## Table of Contents
+
+0. [Project structure](#project-structure)
+0. [Types of contributions we're looking for](#types-of-contributions-were-looking-for)
+0. [Ground rules & expectations](#ground-rules--expectations)
+0. [How to contribute](#how-to-contribute)
+0. [Style guide](#style--guide)
+0. [Community](#community)
+
+## Project structure
+
+The Wangscape project consists of more than one repository:
+* [Wangscape](https://github.com/Wangscape/Wangscape) contains the source code
+of the main Wangscape application, its tests, build files, example data, and
+documentation.
+* [Wangview](https://github.com/Wangscape/Wangview) contains source code for
+Wangview, which can be used to view a map display using Wangscape's output tilesets.
+It also serves as a reference implementation for map displays based on Wangscape
+tilesets.
+* [wangscape-build-dockerfile](https://github.com/Wangscape/wangscape-build-dockerfile) contains configuration files used to build Wangscape in Docker.
+
+## Types of contributions we're looking for
+
+First and foremost, this is an application which generates terrain tilesets. There
+are many ways you can help make Wangscape a better tileset generator:
+* Report bugs, request features, and join discussions about those issues.
+* Improve the use of language, or add missing documentation and code comments.
+* Improve the images and configuration used in examples, or add more examples.
+* Formatting code and making it conform to best practices and project style.
+* Fix bugs or implement new features.
+* Be available to enforce the project Code of Conduct.
+
+## Ground rules & expectations
+
+Before we get started, here are a few things we expect from you (and that you 
+should expect from others):
+
+* Be kind and thoughtful in your conversations around this project. We all come
+from different backgrounds which means we likely have different perspectives on
+how Wangscape should be improved. Try to listen to others rather than convince
+them that your way is correct.
+* Wangscape is released with a [Contributor Code of Conduct](./CODE_OF_CONDUCT.md).
+By participating in this project, you agree to abide by its terms.
+* If you open a pull request, please ensure that your contribution passes all tests.
+If there are test failures, you will need to address them before we can merge your
+contribution.
+
+## How to contribute
+If you'd like to contribute, start by searching through the
+[issues](https://github.com/Wangscape/Wangscape/issues)
+and
+[pull requests](https://github.com/Wangscape/Wangscape/pulls)
+to see whether someone else has raised a similar idea or question.
+
+If you don't see your idea listed, and you think it fits into the goals of this
+project, do one of the following:
+* **If your contribution is minor,** such as a fix for a typo or simple bug,
+**or self-contained,** such as a new example, open a [pull request](https://help.github.com/articles/using-pull-requests).
+* **If your contribution is major,** such as a new feature or fix for a complex
+bug, start by opening an issue first. That way, other people can weigh in on the
+discussion before you do any work.
+
+If you open a pull request, it will be reviewed and discussed by project maintainers,
+who may request changes. After your pull request is approved, one of the maintainers
+may merge the changes into the project.
+
+The current project maintainers are @serin-delaunay and @hryniuk. If you haven't
+heard from anyone about your issue or pull request in 10 days, feel free to bump
+the thread or @-mention a maintainer to discuss or review your contribution.
+
+## Style guide
+If you're writing documentation, comments, or code, see the
+[style guide](./STYLE_GUIDE.md)
+to help your contribution match the rest of the project.
+
+## Community
+Discussions about Wangscape take place on this repository's
+[Issues](https://github.com/Wangscape/Wangscape/issues) and
+[Pull Requests](https://github.com/Wangscape/Wangscape/pulls) sections.
+Anybody is welcome to join these conversations. There is also a
+[Gitter](https://gitter.im/Wangscape/Lobby) channel for real-time discussions.
+
+Wherever possible, do not take these conversations to private channels, including
+contacting the maintainers directly. Keeping communication public means everyone
+can contribute to and learn from the conversation. It also helps to inform future
+work on the project.

--- a/README.md
+++ b/README.md
@@ -16,12 +16,17 @@ A good explanation of the corner Wang tiles (and the related Wang tiles) can be 
 Rather than matching graphical tiles with the representation of logical tiles on screen, corner Wang tiles should be displayed offset by half a tile in both axes. Thus each logical tile is represented by the matching corners of four graphical tiles, and the logical boundary between tiles will pass through the central axes of the graphical tiles. Thus the graphical boundary between tiles can intrude on both sides of the logical boundary, simply by being drawn on one side or the other of the graphical tile.
 
 # How does Wangscape make corner Wang tiles?
+
 * A set of cliques each with up to 4 members is defined on the terrain types. Each clique produces a separate tileset to avoid making excessively large textures.
 * For each valid combination of terrain types in the corners:
     * An alpha mask is generated for each corner (currently it's just a smooth gradient with no randomness).
     * These alpha masks are used to combine each corner's terrain texture into a single tile.
 * In future this will be much more customisable, using Perlin noise to generate noisy gradients and boundaries betwen corners.
 * Currently all tile generation is done through a command-line application configured using a JSON file. In the future, this should be migrated to a GUI interface which allows the user to alter tile generation parameters and immediately see the range of possible results.
+
+# How can I help Wangscape?
+
+We would value your input in bug reports, feature requests, documentation improvements, examples, or code. Please see [CONTRIBUTING.md](./CONTRIBUTING.md) for further information. Note that a [code of conduct](./CODE_OF_CONDUCT.md) applies to all participation in this project.
 
 # How can I build Wangscape?
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,15 @@ Rather than matching graphical tiles with the representation of logical tiles on
 
 We would value your input in bug reports, feature requests, documentation improvements, examples, or code. Please see [CONTRIBUTING.md](./CONTRIBUTING.md) for further information. Note that a [code of conduct](./CODE_OF_CONDUCT.md) applies to all participation in this project.
 
+# What platforms does Wangscape support?
+
+Wangscape is actively tested by the maintainers on:
+* Windows 7 (64-bit) with Visual Studio 2015
+* Arch Linux with CMake
+* Ubuntu (Trusty) with CMake (in travis-ci)
+
+We also hope to run travis-ci builds under Mac OS X soon.
+
 # How can I build Wangscape?
 
 First of all, you need to clone all needed submodules. To get them, execute

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -1,0 +1,146 @@
+#Introduction
+
+Wangscape includes many different types of text, including English prose, C++,
+Python, and JSON. This document provides style guidelines for text contributions
+to the project. This applies to code, comments, documentation, and wiki pages,
+not to discussions on issues, pull requests, and Gitter.
+
+To the best of your ability, the contents of your pull requests should conform
+to this style guide. If for any reason you are less able to conform to this guide
+in your writing, your contributions are still very welcome. Any necessary corrections
+can be made during the review process.
+
+Some of the content already present in Wangscape may not conform to this style
+guide. We welcome contributions which correct these errors, however minor.
+
+If you feel this guide should be altered, please open an issue with your suggestions.
+Possible changes to the style guide should only be discussed in dedicated spaces,
+not in pull requests for features and bugfixes.
+
+#Contents
+0. [English](#english)
+0. [C++](#c)
+0. [Python](#python)
+0. [JSON](#json)
+
+#English
+
+Wangscape is intended to be usable by non-programmers. All documentation related
+to configuration of Wangscape and libnoise module groups should, to the fullest
+extent possible, use language which is accessible to people without a background
+in mathematics or computer science.
+
+However, some understanding of JSON and libnoise modules will be necessary for a
+user to take full advantage of Wangscape's configuration options, and Wangscape
+should not duplicate existing efforts to document these technologies.
+
+External links should be used wherever appropriate, especially to other projects
+and their documentation and tutorials.
+
+All documentation and comments should be clear and precise, while maintaining an
+approachable tone.
+
+##Capitalisation
+
+* Anything named after Hao Wang should capitalise his name. This includes "Wangscape", 
+"Wangview", and "corner Wang tile".
+* libnoise should not be capitalised, even at the start of a sentence.
+
+##Dialect
+* Wangscape uses British English spellings and vocabulary.
+
+#C++
+
+##Naming conventions
+
+###Case
+
+* Names of `class`es, `struct`s, and other types should be in `PascalCase`.
+* Names of `class` and `struct` methods should be in `camelCase`.
+* Names of free functions should be in `camelCase`.
+* Names of static const free variables should be in `UPPER_CASE`.
+* Names of static const data variables should be in `UPPER_CASE`.
+* Names of `class` and `struct` `public` data members which are non-const or non-static
+should be in `camelCase`.
+* Names of `class` and `struct` `protected and `private` data members which are
+non-const or non-static should be in `mCamelCase` with an `m` prefix.
+* Names of non-constructor function parameters should be in `snake_case`.
+* Names of constructor parameters should be in `snake_case_` with a `_` postfix.
+* Names of temporary function-local values should be in `snake_case`.
+* Names of `namespace`s should be in `snake_case`.
+* Names of template type parameters should be in `PascalCase`.
+* Names of template value parameters should be in `PascalCase`.
+* Names of enum values should be in `PascalCase`.
+* Acronyms and initialisms in `PascalCase` and `camelCase` should be written in
+upper case, even at the start of an identifier (`JSONData`).
+
+###Filenames
+Filenames are in `PascalCase`, with `.cpp` and `.h` extensions.
+
+###General
+
+* All identifiers should clearly and concisely describe the purpose of the associated
+type, variable, function, or namespace. 
+* Abbreviations may be used, but only when the meaning is still clear and a significant
+number of characters is saved.
+* Method parameters relating to a data member should not use synonyms, abbreviations,
+or other tricks to avoid name collisions. In the rare cases when a method parameter
+hides a data member, use `this->` to access the data member.
+
+##Brackets and indentation
+
+* Wangscape uses BSD (Allman) style braces, with 4 space indentation.
+* Very short functions may be written on one line, if readability is improved.
+* Single-statement code blocks may be written without braces, if readability is 
+improved **and** it is unlikely that another statement will be added to the block.
+
+##Long lines
+
+* There is no hard limit on line length, but line breaks and appropriate indentation
+should be used to make the code as readable as possible.
+
+##Comments
+* Comments should be used to clarify anything which is not obvious from the code
+itself.
+* Wangscape does not yet use a documentation generator, so there is no specific
+format for class and function documentation comments.
+
+##Modern C++
+* C++14 features should be used wherever possible to make the code safer and more
+readable.
+* Raw pointers should only be used when absolutely necessary (for instance, if
+library code requires raw pointers, or addresses must be compared).
+* Some features of C++14 and C++17 may not yet be supported in the maintainers'
+build environments; these should not be used.
+
+##Other
+* In pointer and reference declarations, there should be a space on the right side
+of the `*` or `&`, and no space on the left.
+* Do not use `using namespace x` declarations.
+
+##Exemptions
+
+Some code in Wangscape is meant to extend public APIs from other projects. Such
+code may diverge from the Wangscape style guide in order to make its own public
+API conform to the base code.
+
+#Python
+
+* Python code should conform to PEP8.
+* `import *` should never be used.
+* The content of IPython notebooks and associated Python modules
+should be synchronised.
+* Names of modules (and filenames) should be in `PascalCase`.
+* Names of `class`es should be in `PascalCase`.
+* Names of functions should be in `snake_case`.
+* Names of class members should be in `snake_case`.
+* Names of free variables should be in `snake_case`.
+
+#JSON
+
+* JSON code should conform to JSON Lint's style.
+* Each indentation level should use a single tab character.
+* JSON values should satisfy the appropriate schema:
+  * Options files should conform to the options schema.
+  * Module group files should conform to the module group schema.
+  * Schemas should conform to draft 4 of the JSON metaschema.


### PR DESCRIPTION
Will eventually resolve #41.

Changes:
* Add Contributor Covenant (CODE_OF_CONDUCT.md).
* Add contribution guide (CONTRIBUTING.md).
* Add style guide (STYLE_GUIDE.md).

TODO:
- [x] Needs at least one more moderator for enforcement (available by direct email and subscribed to wangscape-team@googlegroups.com). @hryniuk, are you willing to take on this role? If so, what email address would you like to use?
- [x] Link to CODE_OF_CONDUCT.md and CONTRIBUTING.md in README.md.
- [x] Mention target platforms somewhere - perhaps README.md rather than CONTRIBUTING.md?
* ~Add clang format file.~ This will be a separate issue.
- [x] Behaviour guidelines for maintaining an inclusive community.
- [x] What kinds of contributions are especially sought.
- [x] Project structure.
- [x] Procedure for contributing to the code, documentation, build system, and other files tracked in the repository.
- [x] Procedure for submitting feature requests, bug reports, wiki changes, and other contributions not tracked in the repository.
- [x] Coding style (may be split into a separate document).
* ~Documentation practices~ (not applicable until a doc generator is configured).