### PR TITLE
Metaoutput schemas

### DIFF
--- a/doc/schemas/module_group_schema.json
+++ b/doc/schemas/module_group_schema.json
@@ -7,7 +7,7 @@
     "defaultoutputmodule": {
       "type": "string",
       "title": "ModuleGroup defaultoutputmodule schema",
-      "description": "Specifies which of the keys in Modules contains the module which should be used for the module group's output."
+      "description": "Specifies which of the keys in 'modules' contains the module which should be used for the module group's output."
     },
     "inputmodules": {
       "type": "array",

--- a/doc/schemas/options_schema.json
+++ b/doc/schemas/options_schema.json
@@ -170,7 +170,7 @@
       "type": "number",
       "title": "AlphaCalculatorTopTwoPower schema",
       "description": "Specifies an exponent to which noise values should be raised before applying TopTwo or related alpha calculators."
-    }
+    },
     "DefaultModuleGroup": {
       "type": "string",
       "title": "DefaultModuleGroup schema",

--- a/doc/schemas/options_schema.json
+++ b/doc/schemas/options_schema.json
@@ -48,12 +48,17 @@
       "additionalProperties": false,
       "properties": {
         "Resolution": {
-          "type": "integer",
+          "type": "array",
           "title": "Tile resolution",
           "description": "Specifies the width and height of the square tiles Wangscape will operate on.",
-          "multipleOf": 1,
-          "maximum": 512,
-          "minimum": 8
+          "items": {
+            "type": "integer",
+            "multipleOf": 1,
+            "maximum": 512,
+            "minimum": 8
+          },
+          "minItems": 2,
+          "maxItems": 2
         },
         "FileType": {
           "type": "string",

--- a/doc/schemas/terrain_hypergraph_schema.json
+++ b/doc/schemas/terrain_hypergraph_schema.json
@@ -2,13 +2,19 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
   "title": "Wangscape terrain hypergraph schema",
-  "description": "Specifies the clique membership of each terrain in a Wangscape configuration",
+  "description": "Specifies the clique memberships of each terrain in a Wangscape configuration",
   "patternProperties":{
     "^[0-9a-zA-Z_-]+$": {
+      "title":"",
+      "description":"",
       "type": "array",
       "items":{
+        "title":"",
+        "description":"",
         "type": "array",
         "items": {
+          "title":"",
+          "description":"",
           "type": "string",
           "pattern": "^[0-9a-zA-Z_-]+$"
         },

--- a/doc/schemas/terrain_hypergraph_schema.json
+++ b/doc/schemas/terrain_hypergraph_schema.json
@@ -10,7 +10,7 @@
       "type": "array",
       "items":{
         "title":"Clique schema",
-        "description":"Specifies a terrain clique as a list of terrain IDs",
+        "description":"Specifies a terrain clique as a list of terrain IDs.",
         "type": "array",
         "items": {
           "title":"Terrain ID schema",

--- a/doc/schemas/terrain_hypergraph_schema.json
+++ b/doc/schemas/terrain_hypergraph_schema.json
@@ -2,19 +2,19 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
   "title": "Wangscape terrain hypergraph schema",
-  "description": "Specifies the clique memberships of each terrain in a Wangscape configuration",
+  "description": "Specifies the clique memberships of each terrain in a Wangscape configuration.",
   "patternProperties":{
     "^[0-9a-zA-Z_-]+$": {
-      "title":"",
-      "description":"",
+      "title":"Clique list schema",
+      "description":"Lists all the cliques which contain a certain terrain.",
       "type": "array",
       "items":{
-        "title":"",
-        "description":"",
+        "title":"Clique schema",
+        "description":"Specifies a terrain clique as a list of terrain IDs",
         "type": "array",
         "items": {
-          "title":"",
-          "description":"",
+          "title":"Terrain ID schema",
+          "description":"Specifies a terrain type.",
           "type": "string",
           "pattern": "^[0-9a-zA-Z_-]+$"
         },

--- a/doc/schemas/terrain_hypergraph_schema.json
+++ b/doc/schemas/terrain_hypergraph_schema.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "title": "Wangscape terrain hypergraph schema",
+  "description": "Specifies the clique membership of each terrain in a Wangscape configuration",
+  "patternProperties":{
+    "^[0-9a-zA-Z_-]+$": {
+      "type": "array",
+      "items":{
+        "type": "array",
+        "items": {
+          "type": "string",
+          "pattern": "^[0-9a-zA-Z_-]+$"
+        },
+        "minItems": 1
+      }
+    }
+  }
+}

--- a/doc/schemas/tile_groups_schema.json
+++ b/doc/schemas/tile_groups_schema.json
@@ -1,32 +1,32 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "title": "",
-  "description": "",
+  "title": "Wangscape tile groups schema",
+  "description": "Lists Wangscape output tiles with locations, grouped by corner terrain types.",
   "patternProperties":{
     "^[0-9a-zA-Z_-]+.[0-9a-zA-Z_-]+.[0-9a-zA-Z_-]+.[0-9a-zA-Z_-]+$": {
       "type": "array",
-      "title":"",
-      "description":"",
+      "title":"Tile group schema",
+      "description":"Lists the locations of all output tiles with a given sequence of corner terrain types.",
       "items":{
         "type": "object",
-        "title":"",
-        "description":"",
+        "title":"Tile location schema",
+        "description":"Specifies the location of a Wangscape output tile.",
         "properties":{
           "filename": {
-            "title":"",
+            "title":"Specifies the filename of the tileset containing the tile.",
             "description":"",
             "type": "string"
           },
           "x": {
-            "title":"",
-            "description":"",
+            "title":"Tile x offset schema",
+            "description":"Specifies the horizontal offset, in pixels, of the tile within the tileset.",
             "type": "integer",
             "minimum": 0
           },
           "y": {
-            "title":"",
-            "description":"",
+            "title":"Tile y offset schema",
+            "description":"Specifies the vertical offset, in pixels, of the tile within the tileset.",
             "type": "integer",
             "minimum": 0
           }

--- a/doc/schemas/tile_groups_schema.json
+++ b/doc/schemas/tile_groups_schema.json
@@ -4,7 +4,7 @@
   "title": "Wangscape tile groups schema",
   "description": "Lists Wangscape output tiles with locations, grouped by corner terrain types.",
   "patternProperties":{
-    "^[0-9a-zA-Z_-]+.[0-9a-zA-Z_-]+.[0-9a-zA-Z_-]+.[0-9a-zA-Z_-]+$": {
+    "^[0-9a-zA-Z_-]+\\.[0-9a-zA-Z_-]+\\.[0-9a-zA-Z_-]+\\.[0-9a-zA-Z_-]+$": {
       "type": "array",
       "title":"Tile group schema",
       "description":"Lists the locations of all output tiles with a given sequence of corner terrain types.",

--- a/doc/schemas/tile_groups_schema.json
+++ b/doc/schemas/tile_groups_schema.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "title": "Wangscape terrain hypergraph schema",
+  "description": "Specifies the clique membership of each terrain in a Wangscape configuration",
+  "patternProperties":{
+    "^[0-9a-zA-Z_-]+.[0-9a-zA-Z_-]+.[0-9a-zA-Z_-]+.[0-9a-zA-Z_-]+$": {
+      "type": "array",
+      "items":{
+        "type": "object",
+        "properties":{
+          "filename": {
+            "type": "string"
+          },
+          "x": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "y": {
+            "type": "integer",
+            "minimum": 0
+          }
+        },
+        "additionalProperties": false,
+        "required":[
+          "filename",
+          "x",
+          "y"
+        ]
+      },
+      "minItems": 1
+    }
+  }
+}

--- a/doc/schemas/tile_groups_schema.json
+++ b/doc/schemas/tile_groups_schema.json
@@ -1,22 +1,32 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "title": "Wangscape terrain hypergraph schema",
-  "description": "Specifies the clique membership of each terrain in a Wangscape configuration",
+  "title": "",
+  "description": "",
   "patternProperties":{
     "^[0-9a-zA-Z_-]+.[0-9a-zA-Z_-]+.[0-9a-zA-Z_-]+.[0-9a-zA-Z_-]+$": {
       "type": "array",
+      "title":"",
+      "description":"",
       "items":{
         "type": "object",
+        "title":"",
+        "description":"",
         "properties":{
           "filename": {
+            "title":"",
+            "description":"",
             "type": "string"
           },
           "x": {
+            "title":"",
+            "description":"",
             "type": "integer",
             "minimum": 0
           },
           "y": {
+            "title":"",
+            "description":"",
             "type": "integer",
             "minimum": 0
           }

--- a/doc/schemas/tiles_schema.json
+++ b/doc/schemas/tiles_schema.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "array",
+  "title": "Wangscape terrain hypergraph schema",
+  "description": "Specifies the clique membership of each terrain in a Wangscape configuration",
+  "items":{
+    "type": "object",
+    "properties":{
+      "corners":{
+        "type": "array",
+        "items": {
+          "type": "string",
+          "pattern": "^[0-9a-zA-Z_-]+$"
+        }
+      },
+      "filename":{
+        "type": "string"
+      },
+      "x":{
+        "type": "integer",
+        "minimum": 0
+      },
+      "y":{
+        "type": "integer",
+        "minimum": 0
+      }
+    }
+  }
+}

--- a/doc/schemas/tiles_schema.json
+++ b/doc/schemas/tiles_schema.json
@@ -34,6 +34,12 @@
         "type": "integer",
         "minimum": 0
       }
-    }
+    },
+    "required":[
+      "corners",
+      "filename",
+      "x",
+      "y"
+    ]
   }
 }

--- a/doc/schemas/tiles_schema.json
+++ b/doc/schemas/tiles_schema.json
@@ -1,36 +1,38 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "array",
-  "title": "",
-  "description": "",
+  "title": "Wangscape tiles schema",
+  "description": "Lists the contents and location of every tile output by a Wangscape project.",
   "items":{
     "type": "object",
-    "title":"",
-    "description":"",
+    "title":"Tile schema",
+    "description":"Specifies the contents and location of a tile output by Wangscape.",
     "properties":{
       "corners":{
-        "title":"",
-        "description":"",
+        "title":"Tile corners schema",
+        "description":"Specifies the IDs of the terrain types at the corners of the tile.",
         "type": "array",
         "items": {
+          "title":"Terrain ID schema",
+          "description":"Specifies a terrain type.",
           "type": "string",
           "pattern": "^[0-9a-zA-Z_-]+$"
         }
       },
       "filename":{
-        "title":"",
-        "description":"",
+        "title":"Tile filename schema",
+        "description":"Specifies the filename of the tileset containing the tile.",
         "type": "string"
       },
       "x":{
-        "title":"",
-        "description":"",
+        "title":"Tile x offset schema",
+        "description":"Specifies the horizontal offset, in pixels, of the tile within the tileset.",
         "type": "integer",
         "minimum": 0
       },
       "y":{
-        "title":"",
-        "description":"",
+        "title":"Tile y offset schema",
+        "description":"Specifies the vertical offset, in pixels, of the tile within the tileset",
         "type": "integer",
         "minimum": 0
       }

--- a/doc/schemas/tiles_schema.json
+++ b/doc/schemas/tiles_schema.json
@@ -1,12 +1,16 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "array",
-  "title": "Wangscape terrain hypergraph schema",
-  "description": "Specifies the clique membership of each terrain in a Wangscape configuration",
+  "title": "",
+  "description": "",
   "items":{
     "type": "object",
+    "title":"",
+    "description":"",
     "properties":{
       "corners":{
+        "title":"",
+        "description":"",
         "type": "array",
         "items": {
           "type": "string",
@@ -14,13 +18,19 @@
         }
       },
       "filename":{
+        "title":"",
+        "description":"",
         "type": "string"
       },
       "x":{
+        "title":"",
+        "description":"",
         "type": "integer",
         "minimum": 0
       },
       "y":{
+        "title":"",
+        "description":"",
         "type": "integer",
         "minimum": 0
       }

--- a/doc/schemas/tilesets_schema.json
+++ b/doc/schemas/tilesets_schema.json
@@ -1,12 +1,16 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "array",
-  "title": "Wangscape terrain hypergraph schema",
-  "description": "Specifies the clique membership of each terrain in a Wangscape configuration",
+  "title": "",
+  "description": "",
   "items":{
+    "title":"",
+    "description":"",
     "type": "object",
     "properties":{
       "resolution":{
+        "title":"",
+        "description":"",
         "type": "array",
         "items": {
           "type": "integer",
@@ -14,17 +18,26 @@
         }
       },
       "filename":{
+        "title":"",
+        "description":"",
         "type": "string"
       },
       "x":{
+        "title":"",
+        "description":"",
         "type": "integer",
         "minimum": 1
       },
       "y":{
+        "title":"",
+        "description":"",
         "type": "integer",
         "minimum": 1
       },
       "terrains":{
+        "type": "array",
+        "title":"",
+        "description":"",
         "items": {
           "type": "string",
           "pattern": "^[0-9a-zA-Z_-]+$"

--- a/doc/schemas/tilesets_schema.json
+++ b/doc/schemas/tilesets_schema.json
@@ -1,47 +1,52 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "array",
-  "title": "",
-  "description": "",
+  "title": "Wangscape tilesets schema",
+  "description": "Specifies the contents and locations of Wangscape output tilesets.",
   "items":{
-    "title":"",
-    "description":"",
+    "title":"Tileset schema",
+    "description":"Specifies the terrains, filename, resolution, and tile resolution of a Wangscape output tileset.",
     "type": "object",
     "properties":{
       "resolution":{
-        "title":"",
-        "description":"",
+        "title":"Tile resolution schema",
+        "description":"Specifies the resolution of tiles in the tileset.",
         "type": "array",
         "items": {
           "type": "integer",
           "minimum": 1
-        }
+        },
+        "minItems":2,
+        "maxItems":2
       },
       "filename":{
-        "title":"",
-        "description":"",
+        "title":"Tileset filename schema",
+        "description":"Specifies the filename of the image containing the tileset.",
         "type": "string"
       },
       "x":{
-        "title":"",
-        "description":"",
+        "title":"Tileset x resolution schema",
+        "description":"Specifies the horizontal resolution of the whole tileset.",
         "type": "integer",
         "minimum": 1
       },
       "y":{
-        "title":"",
-        "description":"",
+        "title":"Tileset y resolution schema",
+        "description":"Specifies the vertical resolution of the whole tileset.",
         "type": "integer",
         "minimum": 1
       },
       "terrains":{
         "type": "array",
-        "title":"",
-        "description":"",
+        "title":"Tileset terrains schema",
+        "description":"Specifies the IDs of the terrain types used in the tileset.",
         "items": {
+          "title":"Terrain ID schema",
+          "description":"Specifies a terrain type.",
           "type": "string",
           "pattern": "^[0-9a-zA-Z_-]+$"
-        }
+        },
+        "minLength": 2
       }
     },
     "required":[

--- a/doc/schemas/tilesets_schema.json
+++ b/doc/schemas/tilesets_schema.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "array",
+  "title": "Wangscape terrain hypergraph schema",
+  "description": "Specifies the clique membership of each terrain in a Wangscape configuration",
+  "items":{
+    "type": "object",
+    "properties":{
+      "resolution":{
+        "type": "array",
+        "items": {
+          "type": "integer",
+          "minimum": 1
+        }
+      },
+      "filename":{
+        "type": "string"
+      },
+      "x":{
+        "type": "integer",
+        "minimum": 1
+      },
+      "y":{
+        "type": "integer",
+        "minimum": 1
+      },
+      "terrains":{
+        "items": {
+          "type": "string",
+          "pattern": "^[0-9a-zA-Z_-]+$"
+        }
+      }
+    }
+  }
+}

--- a/doc/schemas/tilesets_schema.json
+++ b/doc/schemas/tilesets_schema.json
@@ -43,6 +43,13 @@
           "pattern": "^[0-9a-zA-Z_-]+$"
         }
       }
-    }
+    },
+    "required":[
+      "resolution",
+      "filename",
+      "x",
+      "y",
+      "terrains"
+    ]
   }
 }


### PR DESCRIPTION
For use in https://github.com/serin-delaunay/Wangcheck/tree/check-metaoutput, as part of the resolution to #21.

Branched from #112 because this branch needs all schemas to be correct in order for Wangcheck to work.

TODO:
- [x] Fill in all `title` and `description` fields:
  - [x] Terrain hypergraph schema.
  - [x] Tiles schema.
  - [x] Tile groups schema.
  - [x] Tilesets schema.
- [x] Add missing `required` fields.
