### PR TITLE
Support appveyor builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Wangscape [![Build Status](https://travis-ci.org/Wangscape/Wangscape.svg?branch=master)](https://travis-ci.org/Wangscape/Wangscape) [![Gitter chat](https://badges.gitter.im/Wangscape.png)](https://gitter.im/Wangscape/Lobby)
+# Wangscape [![Build Status](https://travis-ci.org/Wangscape/Wangscape.svg?branch=master)](https://travis-ci.org/Wangscape/Wangscape) [![Build status](https://ci.appveyor.com/api/projects/status/qob6o9umrf5nwidl?svg=true)](https://ci.appveyor.com/project/serin-delaunay/wangscape) [![Gitter chat](https://badges.gitter.im/Wangscape.png)](https://gitter.im/Wangscape/Lobby)
 
 Converts terrain tiles to procedural corner Wang tilesets.
 

--- a/Wangscape/Wangscape.vcxproj
+++ b/Wangscape/Wangscape.vcxproj
@@ -338,7 +338,6 @@
     <Import Project="..\packages\sfml-window.redist.2.4.0.0\build\native\sfml-window.redist.targets" Condition="Exists('..\packages\sfml-window.redist.2.4.0.0\build\native\sfml-window.redist.targets')" />
     <Import Project="..\packages\sfml-window.2.4.0.0\build\native\sfml-window.targets" Condition="Exists('..\packages\sfml-window.2.4.0.0\build\native\sfml-window.targets')" />
     <Import Project="..\packages\sfml-graphics.2.4.0.0\build\native\sfml-graphics.targets" Condition="Exists('..\packages\sfml-graphics.2.4.0.0\build\native\sfml-graphics.targets')" />
-    <Import Project="..\packages\Eigen.3.2.9\build\native\Eigen.targets" Condition="Exists('..\packages\Eigen.3.2.9\build\native\Eigen.targets')" />
     <Import Project="..\packages\boost.1.63.0.0\build\native\boost.targets" Condition="Exists('..\packages\boost.1.63.0.0\build\native\boost.targets')" />
     <Import Project="..\packages\boost_filesystem-vc140.1.63.0.0\build\native\boost_filesystem-vc140.targets" Condition="Exists('..\packages\boost_filesystem-vc140.1.63.0.0\build\native\boost_filesystem-vc140.targets')" />
     <Import Project="..\packages\boost_program_options-vc140.1.63.0.0\build\native\boost_program_options-vc140.targets" Condition="Exists('..\packages\boost_program_options-vc140.1.63.0.0\build\native\boost_program_options-vc140.targets')" />
@@ -355,7 +354,6 @@
     <Error Condition="!Exists('..\packages\sfml-window.redist.2.4.0.0\build\native\sfml-window.redist.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\sfml-window.redist.2.4.0.0\build\native\sfml-window.redist.targets'))" />
     <Error Condition="!Exists('..\packages\sfml-window.2.4.0.0\build\native\sfml-window.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\sfml-window.2.4.0.0\build\native\sfml-window.targets'))" />
     <Error Condition="!Exists('..\packages\sfml-graphics.2.4.0.0\build\native\sfml-graphics.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\sfml-graphics.2.4.0.0\build\native\sfml-graphics.targets'))" />
-    <Error Condition="!Exists('..\packages\Eigen.3.2.9\build\native\Eigen.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Eigen.3.2.9\build\native\Eigen.targets'))" />
     <Error Condition="!Exists('..\packages\boost.1.63.0.0\build\native\boost.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\boost.1.63.0.0\build\native\boost.targets'))" />
     <Error Condition="!Exists('..\packages\boost_filesystem-vc140.1.63.0.0\build\native\boost_filesystem-vc140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\boost_filesystem-vc140.1.63.0.0\build\native\boost_filesystem-vc140.targets'))" />
     <Error Condition="!Exists('..\packages\boost_program_options-vc140.1.63.0.0\build\native\boost_program_options-vc140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\boost_program_options-vc140.1.63.0.0\build\native\boost_program_options-vc140.targets'))" />

--- a/Wangscape/libnoise.props
+++ b/Wangscape/libnoise.props
@@ -3,8 +3,8 @@
   <ImportGroup Label="PropertySheets" />
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
-    <LibraryPath>C:\Users\Serin\Documents\Visual Studio 2015\Projects\Wangscape\lib\libnoise\build\src\$(Configuration);$(LibraryPath)</LibraryPath>
-    <IncludePath>C:\Users\Serin\Documents\Visual Studio 2015\Projects\Wangscape\lib\libnoise\src;$(IncludePath)</IncludePath>
+    <LibraryPath>$(SolutionDir)lib\libnoise\build\src\$(Configuration);$(LibraryPath)</LibraryPath>
+    <IncludePath>$(SolutionDir)lib\libnoise\src;$(IncludePath)</IncludePath>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile />

--- a/Wangscape/tilegen/partition/TilePartitionerGradient.cpp
+++ b/Wangscape/tilegen/partition/TilePartitionerGradient.cpp
@@ -12,7 +12,7 @@ int TilePartitionerGradient::gradientWeight(sf::Vector2u xy, sf::Vector2u corner
     sf::Vector2i distance = {std::abs((int)xy.x - (int)corner.x), std::abs((int)xy.y - (int)corner.y)};
     sf::Vector2i size = sf::Vector2i(mOptions.tileFormat.resolution) - sf::Vector2i(margin);
     sf::Vector2i values = size - distance;
-    return std::max({0, values.x, values.y});
+    return std::max({0, std::min(values.x, values.y)});
 }
 
 void TilePartitionerGradient::makePartition(TilePartition & regions,

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -51,6 +51,11 @@ before_build:
 build:
   project: Wangscape.sln
   verbosity: minimal
+after_build:
+- cmd: >-
+    Release\Wangscape.exe doc\examples\example3\example_options.json
+
+    7z a example3_output.zip doc\examples\example3\output
 test_script:
 - cmd: Release\WangscapeTest.exe --gtest_output=xml --gtest_filter=-*Squares*
 after_test:
@@ -59,5 +64,10 @@ after_test:
 
     $wc.UploadFile("https://ci.appveyor.com/api/testresults/xunit/$($env:APPVEYOR_JOB_ID)", (Resolve-Path .\test_detail.xml))
 artifacts:
-- path: Release\Wangscape.exe
-- path: Release\WangscapeTest.exe
+  - path: Release\Wangscape.exe
+    name: Wangscape executable
+  - path: Release\WangscapeTest.exe
+    name: Wangscape Test executable
+  - path: example3_output.zip
+    name: Example 3 output
+    type: zip

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -53,11 +53,11 @@ build:
   verbosity: minimal
 test_script:
 - cmd: Release\WangscapeTest.exe --gtest_output=xml --gtest_filter=-*Squares*
-#after_test:
-#- ps: >-
-#    $wc = New-Object 'System.Net.WebClient'
-#
-#    $wc.UploadFile("https://ci.appveyor.com/api/testresults/xunit/$($env:APPVEYOR_JOB_ID)", (Resolve-Path .\test_detail.xml))
+after_test:
+- ps: >-
+    $wc = New-Object 'System.Net.WebClient'
+
+    $wc.UploadFile("https://ci.appveyor.com/api/testresults/xunit/$($env:APPVEYOR_JOB_ID)", (Resolve-Path .\test_detail.xml))
 artifacts:
 - path: Release\Wangscape.exe
 - path: Release\WangscapeTest.exe

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -53,11 +53,11 @@ build:
   verbosity: minimal
 test_script:
 - cmd: Release\WangscapeTest.exe --gtest_output=xml
-after_test:
-- ps: >-
-    $wc = New-Object 'System.Net.WebClient'
-
-    $wc.UploadFile("https://ci.appveyor.com/api/testresults/xunit/$($env:APPVEYOR_JOB_ID)", (Resolve-Path .\test_detail.xml))
+#after_test:
+#- ps: >-
+#    $wc = New-Object 'System.Net.WebClient'
+#
+#    $wc.UploadFile("https://ci.appveyor.com/api/testresults/xunit/$($env:APPVEYOR_JOB_ID)", (Resolve-Path .\test_detail.xml))
 artifacts:
 - path: Release\Wangscape.exe
 - path: Release\WangscapeTest.exe

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,42 @@
+version: 0.1.{build}
+image: Visual Studio 2015
+configuration: Release
+platform: x86
+cache: packages
+nuget:
+  project_feed: true
+before_build:
+- cmd: >-
+    del "C:\Program Files (x86)\MSBuild\14.0\Microsoft.Common.targets\ImportAfter\Xamarin.Common.targets"
+    echo Restoring Nuget Packages
+    nuget restore
+    echo Fetching submodules
+    git submodule update --init --recursive
+    cd lib\spotify-json
+    echo Building spotify-json
+    mkdir build32
+    cd build32
+    cmake .. -DBoost_NO_BOOST_CMAKE=TRUE -DBOOST_ROOT=..\..\..\packages\boost.1.63.0.0\lib\native
+    cmake --build . --config Release
+    cd ..
+    cd ..\..
+    cd lib\libnoise
+    echo Building libnoise
+    mkdir build
+    cd build
+    cmake ..
+    cmake --build . --config Release
+    cd ..
+    cd ..\..
+build:
+  project: Wangscape.sln
+  verbosity: minimal
+test_script:
+- cmd: Release\WangscapeTest.exe --gtest_output=xml
+after_test:
+- ps: >-
+    $wc = New-Object 'System.Net.WebClient'
+    $wc.UploadFile("https://ci.appveyor.com/api/testresults/xunit/$($env:APPVEYOR_JOB_ID)", (Resolve-Path .\test_detail.xml))
+artifacts:
+- path: Release\Wangscape.exe
+- path: Release\WangscapeTest.exe

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,25 +8,45 @@ nuget:
 before_build:
 - cmd: >-
     del "C:\Program Files (x86)\MSBuild\14.0\Microsoft.Common.targets\ImportAfter\Xamarin.Common.targets"
+    
     echo Restoring Nuget Packages
+
     nuget restore
+
     echo Fetching submodules
+
     git submodule update --init --recursive
+
     cd lib\spotify-json
+
     echo Building spotify-json
+
     mkdir build32
+
     cd build32
+
     cmake .. -DBoost_NO_BOOST_CMAKE=TRUE -DBOOST_ROOT=..\..\..\packages\boost.1.63.0.0\lib\native
+
     cmake --build . --config Release
+
     cd ..
+
     cd ..\..
+
     cd lib\libnoise
+
     echo Building libnoise
+
     mkdir build
+
     cd build
+
     cmake ..
+
     cmake --build . --config Release
+
     cd ..
+
     cd ..\..
 build:
   project: Wangscape.sln
@@ -36,6 +56,7 @@ test_script:
 after_test:
 - ps: >-
     $wc = New-Object 'System.Net.WebClient'
+
     $wc.UploadFile("https://ci.appveyor.com/api/testresults/xunit/$($env:APPVEYOR_JOB_ID)", (Resolve-Path .\test_detail.xml))
 artifacts:
 - path: Release\Wangscape.exe

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -52,7 +52,7 @@ build:
   project: Wangscape.sln
   verbosity: minimal
 test_script:
-- cmd: Release\WangscapeTest.exe --gtest_output=xml
+- cmd: Release\WangscapeTest.exe --gtest_output=xml --gtest_filter=-*Squares*
 #after_test:
 #- ps: >-
 #    $wc = New-Object 'System.Net.WebClient'


### PR DESCRIPTION
Will eventually resolve #20.

Changes:
* Remove old references to Eigen Nuget package.
* Fix libnoise props file.
* Add appveyor,yml.
* Add Appveyor badge to README.md.
* Fix calculation error in `TilePartitionerGradient::gradientWeight`.
* Skip `TestTilePartitionerSquares` because it causes Appveyor to crash (probably due to an out of date OpenGL version?).