### PR TITLE
Travis: Exclude tests that require X11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,4 @@ services:
 script:
     - pwd
     - mkdir build
-    - docker run -v $(pwd):/Wangscape lukequaint/wangscape-build:latest /bin/sh -c "cd /Wangscape/build && cmake .. && make && ./bin/WangscapeTest ../doc --gtest_filter=-*TestMetaOutput*:*Squares*:*TestGradientPartition*"
+    - docker run -v $(pwd):/Wangscape lukequaint/wangscape-build:latest /bin/sh -c "cd /Wangscape/build && cmake .. && make && ./bin/WangscapeTest ../doc --gtest_filter=-*TestMetaOutput*:*Squares*:*TestGradientPartition*:*TestTilesetGenerator*"

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,4 @@ services:
 script:
     - pwd
     - mkdir build
-    - docker run -v $(pwd):/Wangscape lukequaint/wangscape-build:latest /bin/sh -c "cd /Wangscape/build && cmake .. && make && ./bin/WangscapeTest ../doc"
+    - docker run -v $(pwd):/Wangscape lukequaint/wangscape-build:latest /bin/sh -c "cd /Wangscape/build && cmake .. && make && ./bin/WangscapeTest ../doc --gtest_filter=-*TestMetaOutput*:*Squares*"

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,4 @@ services:
 script:
     - pwd
     - mkdir build
-    - docker run -v $(pwd):/Wangscape lukequaint/wangscape-build:latest /bin/sh -c "cd /Wangscape/build && cmake .. && make && ./bin/WangscapeTest ../doc --gtest_filter=-*TestMetaOutput*:*Squares*"
+    - docker run -v $(pwd):/Wangscape lukequaint/wangscape-build:latest /bin/sh -c "cd /Wangscape/build && cmake .. && make && ./bin/WangscapeTest ../doc --gtest_filter=-*TestMetaOutput*:*Squares*:*TestTilePartitionerGradient*"

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,4 @@ services:
 script:
     - pwd
     - mkdir build
-    - docker run -v $(pwd):/Wangscape lukequaint/wangscape-build:latest /bin/sh -c "cd /Wangscape/build && cmake .. && make && ./bin/WangscapeTest ../doc --gtest_filter=-*TestMetaOutput*:*Squares*:*TestTilePartitionerGradient*"
+    - docker run -v $(pwd):/Wangscape lukequaint/wangscape-build:latest /bin/sh -c "cd /Wangscape/build && cmake .. && make && ./bin/WangscapeTest ../doc --gtest_filter=-*TestMetaOutput*:*Squares*:*TestGradientPartition*"


### PR DESCRIPTION
As a workaround for #95, makes WangscapeTest skip test matching the following patterns in Travis:
* `*TestMetaOutput*`
* `*Squares*`
* `*TestGradientPartition*`
* `*TestTilesetGenerator*`

Currently they cause the test executable to crash, so any tests after the failed test don't get run. These can be reinstated when Travis tests run with Xvfb.

`TestTilePartitionerGradient.TestGradientWeight` fails due to a legitimate bug (missing `std::min` call), which is fixed in #116. #116 doesn't yet address everything in #20; it's missing packaging instructions. Implementing packaging could be done in a different PR, if necessary.