### PR TITLE
Appveyor: Fix spotify-json build and OpenGL in tests

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -52,7 +52,7 @@ build:
   project: Wangscape.sln
   verbosity: minimal
 after_build:
-- ps2: >-
+- ps: >-
     $webclient = New-Object System.Net.WebClient
     
     $basedir = $pwd.Path + "\"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -73,7 +73,7 @@ after_build:
 
     7z a example3_output.zip doc\examples\example3\output
 test_script:
-- ps2: >-
+- cmd: >-
     Release\WangscapeTest.exe --gtest_output=xml --gtest_filter=-*Squares*
 after_test:
 - ps: >-

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -56,6 +56,23 @@ after_build:
     Release\Wangscape.exe doc\examples\example3\example_options.json
 
     7z a example3_output.zip doc\examples\example3\output
+before_test:
+- ps2: >-
+    $webclient = New-Object System.Net.WebClient
+    
+    $basedir = $pwd.Path + "\"
+    
+    $filepath = $basedir + "opengl32.dll"
+    
+    # Download and retry up to 3 times in case of network transient errors.
+    
+    $url = "http://download.qt.io/development_releases/prebuilt/llvmpipe/windows/opengl32sw-32.7z"
+    
+    $webclient.DownloadFile($url, $filepath)
+    
+    7z x opengl32sw-32.7z
+    
+    move opengl32sw.dll Release\opengl32.dll
 test_script:
 - cmd: Release\WangscapeTest.exe --gtest_output=xml --gtest_filter=-*Squares*
 after_test:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -57,7 +57,7 @@ after_build:
     
     $basedir = $pwd.Path + "\"
     
-    $filepath = $basedir + "opengl32.dll"
+    $filepath = $basedir + "opengl32sw-32.7z"
     
     # Download and retry up to 3 times in case of network transient errors.
     

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -52,45 +52,28 @@ build:
   project: Wangscape.sln
   verbosity: minimal
 after_build:
-- cmd: >-
+- ps2: >-
+    $webclient = New-Object System.Net.WebClient
+    
+    $basedir = $pwd.Path + "\"
+    
+    $filepath = $basedir + "opengl32.dll"
+    
+    # Download and retry up to 3 times in case of network transient errors.
+    
+    $url = "http://download.qt.io/development_releases/prebuilt/llvmpipe/windows/opengl32sw-32.7z"
+    
+    $webclient.DownloadFile($url, $filepath)
+    
+    7z x opengl32sw-32.7z
+    
+    move opengl32sw.dll Release\opengl32.dll
+
     Release\Wangscape.exe doc\examples\example3\example_options.json
 
     7z a example3_output.zip doc\examples\example3\output
-before_test:
-- ps2: >-
-    $webclient = New-Object System.Net.WebClient
-    
-    $basedir = $pwd.Path + "\"
-    
-    $filepath = $basedir + "opengl32.dll"
-    
-    # Download and retry up to 3 times in case of network transient errors.
-    
-    $url = "http://download.qt.io/development_releases/prebuilt/llvmpipe/windows/opengl32sw-32.7z"
-    
-    $webclient.DownloadFile($url, $filepath)
-    
-    7z x opengl32sw-32.7z
-    
-    move opengl32sw.dll Release\opengl32.dll
 test_script:
 - ps2: >-
-    $webclient = New-Object System.Net.WebClient
-    
-    $basedir = $pwd.Path + "\"
-    
-    $filepath = $basedir + "opengl32.dll"
-    
-    # Download and retry up to 3 times in case of network transient errors.
-    
-    $url = "http://download.qt.io/development_releases/prebuilt/llvmpipe/windows/opengl32sw-32.7z"
-    
-    $webclient.DownloadFile($url, $filepath)
-    
-    7z x opengl32sw-32.7z
-    
-    move opengl32sw.dll Release\opengl32.dll
-    
     Release\WangscapeTest.exe --gtest_output=xml --gtest_filter=-*Squares*
 after_test:
 - ps: >-

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -74,7 +74,24 @@ before_test:
     
     move opengl32sw.dll Release\opengl32.dll
 test_script:
-- cmd: Release\WangscapeTest.exe --gtest_output=xml --gtest_filter=-*Squares*
+- ps2: >-
+    $webclient = New-Object System.Net.WebClient
+    
+    $basedir = $pwd.Path + "\"
+    
+    $filepath = $basedir + "opengl32.dll"
+    
+    # Download and retry up to 3 times in case of network transient errors.
+    
+    $url = "http://download.qt.io/development_releases/prebuilt/llvmpipe/windows/opengl32sw-32.7z"
+    
+    $webclient.DownloadFile($url, $filepath)
+    
+    7z x opengl32sw-32.7z
+    
+    move opengl32sw.dll Release\opengl32.dll
+    
+    Release\WangscapeTest.exe --gtest_output=xml --gtest_filter=-*Squares*
 after_test:
 - ps: >-
     $wc = New-Object 'System.Net.WebClient'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,7 +25,7 @@ before_build:
 
     cd build32
 
-    cmake .. -DBoost_NO_BOOST_CMAKE=TRUE -DBOOST_ROOT=..\..\..\packages\boost.1.63.0.0\lib\native
+    cmake .. -DBoost_NO_BOOST_CMAKE=TRUE -DBOOST_ROOT=../../../packages/boost.1.63.0.0/lib/native
 
     cmake --build . --config Release
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -74,7 +74,7 @@ after_build:
     7z a example3_output.zip doc\examples\example3\output
 test_script:
 - cmd: >-
-    Release\WangscapeTest.exe --gtest_output=xml --gtest_filter=-*Squares*
+    Release\WangscapeTest.exe --gtest_output=xml
 after_test:
 - ps: >-
     $wc = New-Object 'System.Net.WebClient'


### PR DESCRIPTION
* Replace offending backslashes with slashes.
* Use Qt's mingw build of OpenGL Mesa to replace the default Windows implementation.
* Re-enable `TilePartitionerSquares` tests, since they don't cause Appveyor to crash any more.

Resolves #120 and #117.