### PR TITLE
Remove extra copy of abs schema reference

### DIFF
--- a/doc/schemas/module_group_schema.json
+++ b/doc/schemas/module_group_schema.json
@@ -28,7 +28,6 @@
           {"$ref": "#/definitions/add"},
           {"$ref": "#/definitions/billow"},
           {"$ref": "#/definitions/blend"},
-          {"$ref": "#/definitions/abs"},
           {"$ref": "#/definitions/checkerboard"},
           {"$ref": "#/definitions/clamp"},
           {"$ref": "#/definitions/const"},


### PR DESCRIPTION
This caused valid configuration files to fail Wangcheck: https://ci.appveyor.com/project/serin-delaunay/wangscape/build/0.1.194#L2161