### PR TITLE
Include licenses in AppVeyor binary packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ Wangscape depends on these libraries:
 * **SFML 2**
   - system
   - graphics
+* **Armadillo**
+  - **OpenBLAS**
 * **spotify-json** (submodule)
   - **double-conversion** (submodule)
 * **libnoise** (submodule)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -115,11 +115,11 @@ after_build:
     
     mkdir licenses
     
-    xcopy ..\..\lib\googletest\googletest\LICENSE licenses\LICENSE_googletest.txt
+    copy ..\..\lib\googletest\googletest\LICENSE licenses\LICENSE_googletest.txt
     
-    xcopy ..\..\lib\libnoise\LICENSE licenses\LICENSE_libnoise.txt
+    copy ..\..\lib\libnoise\LICENSE licenses\LICENSE_libnoise.txt
     
-    xcopy ..\..\lib\spotify-json\LICENSE licenses\LICENSE_spotify-json.txt
+    copy ..\..\lib\spotify-json\LICENSE licenses\LICENSE_spotify-json.txt
     
     $webclient.DownloadFile("https://raw.githubusercontent.com/google/double-conversion/master/LICENSE", "licenses\LICENSE_double-conversion.txt")
     

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -121,11 +121,11 @@ after_build:
     
     copy ..\..\lib\spotify-json\LICENSE licenses\LICENSE_spotify-json.txt
     
-    $webclient.DownloadFile("https://raw.githubusercontent.com/google/double-conversion/master/LICENSE", "licenses\LICENSE_double-conversion.txt")
+    Start-FileDownload "https://raw.githubusercontent.com/google/double-conversion/master/LICENSE" -FileName "licenses\LICENSE_double-conversion.txt"
     
-    $webclient.DownloadFile("https://raw.githubusercontent.com/conradsnicta/armadillo-code/unstable/LICENSE.txt", "licenses\LICENSE_Armadillo.txt")
+    Start-FileDownload "https://raw.githubusercontent.com/conradsnicta/armadillo-code/unstable/LICENSE.txt" -FileName "licenses\LICENSE_Armadillo.txt"
     
-    $webclient.DownloadFile("https://raw.githubusercontent.com/xianyi/OpenBLAS/develop/LICENSE", "licenses\LICENSE_OpenBLAS.txt")
+    Start-FileDownload "https://raw.githubusercontent.com/xianyi/OpenBLAS/develop/LICENSE" -FileName "licenses\LICENSE_OpenBLAS.txt"
     
     cd ..
     

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -113,6 +113,20 @@ after_build:
     
     xcopy /s /i ..\..\doc doc
     
+    mkdir licenses
+    
+    xcopy ..\..\lib\googletest\googletest\LICENSE licenses\LICENSE_googletest.txt
+    
+    xcopy ..\..\lib\libnoise\LICENSE licenses\LICENSE_libnoise.txt
+    
+    xcopy ..\..\lib\spotify-json\LICENSE licenses\LICENSE_spotify-json.txt
+    
+    $webclient.DownloadFile("https://raw.githubusercontent.com/google/double-conversion/master/LICENSE", "licenses\LICENSE_double-conversion.txt")
+    
+    $webclient.DownloadFile("https://raw.githubusercontent.com/conradsnicta/armadillo-code/unstable/LICENSE.txt", "licenses\LICENSE_Armadillo.txt")
+    
+    $webclient.DownloadFile("https://raw.githubusercontent.com/xianyi/OpenBLAS/develop/LICENSE", "licenses\LICENSE_OpenBLAS.txt")
+    
     cd ..
     
     7z a Wangscape.zip Wangscape


### PR DESCRIPTION
Required: googletest, libnoise, spotify-json, double-conversion, Armadillo, OpenBLAS
Optional, skipped: SFML, cpp_utils, Boost

To do:
- [x] Mention Armadillo and OpenBLAS in `README.md`.