### PR TITLE
Fix missing space in Bitmap messages

### DIFF
--- a/Wangscape/noise/module/Bitmap.cpp
+++ b/Wangscape/noise/module/Bitmap.cpp
@@ -105,7 +105,7 @@ void Bitmap::setCurrentImage(const std::string & filename, ImagePtr image)
 sf::Image Bitmap::loadNewImage(const std::string & file_path)
 {
     sf::Image sf_bitmap;
-    logInfo() << "Loading image at " << file_path << "into Bitmap module";
+    logInfo() << "Loading image at " << file_path << " into Bitmap module";
     if (!sf_bitmap.loadFromFile(file_path))
     {
         logError() << "Could not load image";


### PR DESCRIPTION
`Loading image at configurations\zigzag\zigzag.pnginto Bitmap module` -> `Loading image at configurations\zigzag\zigzag.png into Bitmap module`