### PR TITLE
Fix Bitmap and Voronoi schemas

### DIFF
--- a/doc/schemas/module_group_schema.json
+++ b/doc/schemas/module_group_schema.json
@@ -1078,14 +1078,10 @@
           "title": "RidgedMulti module Seed schema",
           "description": "Specifies the value of Seed used in this RidgedMulti module.",
           "multipleOf": 1
-        },
-        "SourceModule": {
-          "$ref": "#/definitions/source_module_1"
         }
       },
       "required": [
-        "type",
-        "SourceModule"
+        "type"
       ]
     },
     "rotate_point": {

--- a/doc/schemas/module_group_schema.json
+++ b/doc/schemas/module_group_schema.json
@@ -230,6 +230,11 @@
           "title": "Bitmap module Filename schema",
           "description": "Specifies the filename of the image used in this Bitmap module."
         },
+        "MaxScale":{
+          "type": "boolean",
+          "title": "Bitmap module MaxScale schema",
+          "description": "Specifies the value of MaxScale used in this Bitmap module."
+        },
         "Region":{
           "type":"array",
           "title": "Bitmap module Region schema",
@@ -253,7 +258,7 @@
       },
       "required": [
         "type",
-        "SourceModule"
+        "Filename"
       ]
     },
     "blend": {
@@ -1516,8 +1521,7 @@
         }
       },
       "required": [
-        "type",
-        "SourceModule"
+        "type"
       ]
     }
   }


### PR DESCRIPTION
They don't need source modules, and MaxScale was missing. 

These schemas passed tests, so the tests should be updated to prevent these kinds of errors. Perhaps that should be a separate issue, though.

Required for https://github.com/Wangscape/Wangscape-examples to pass Wangcheck.