### PR TITLE
Convert menu actions to buttons

### DIFF
--- a/WangscapeGui/MainWindow.cpp
+++ b/WangscapeGui/MainWindow.cpp
@@ -31,9 +31,8 @@ MainWindow::MainWindow(QWidget *parent_) :
 
     connect(mUi->generateButton, SIGNAL(pressed()), this, SLOT(generate()));
     connect(mUi->comboBox, SIGNAL(activated(const QString&)), this, SLOT(displayTilesetPreview(const QString&)));
-    connect(mUi->actionLoadOptions, SIGNAL(triggered()), this, SLOT(loadOptionsFromFile()));
-    connect(mUi->actionSaveOutput, SIGNAL(triggered()), this, SLOT(saveOutput()));
-    connect(mUi->actionOpenOptionsEditor, SIGNAL(triggered()), this, SLOT(openOptionsEditor()));
+    connect(mUi->saveButton, SIGNAL(pressed()), this, SLOT(saveOutput()));
+    connect(mUi->optionsButton, SIGNAL(pressed()), this, SLOT(openOptionsEditor()));
 }
 
 MainWindow::~MainWindow()
@@ -67,6 +66,9 @@ void MainWindow::generate()
 
     initializePreviewArea();
     displayTilesetPreview();
+
+    mUi->comboBox->setEnabled(true);
+    mUi->saveButton->setEnabled(true);
 }
 
 void MainWindow::saveOutput()
@@ -143,6 +145,9 @@ void MainWindow::loadOptionsFromFile()
     resetOptions();
 
     resetTilesetGenerator();
+
+    mUi->generateButton->setEnabled(true);
+    mUi->saveButton->setEnabled(false);
 
     mUi->comboBox->clear();
     mPreviewImages.clear();

--- a/WangscapeGui/MainWindow.ui
+++ b/WangscapeGui/MainWindow.ui
@@ -64,6 +64,9 @@
       </property>
       <item>
        <widget class="QComboBox" name="comboBox">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
         <property name="sizePolicy">
          <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
           <horstretch>2</horstretch>
@@ -74,6 +77,9 @@
       </item>
       <item>
        <widget class="QPushButton" name="generateButton">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
         <property name="sizePolicy">
          <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
           <horstretch>1</horstretch>
@@ -81,7 +87,31 @@
          </sizepolicy>
         </property>
         <property name="text">
-         <string>Generate tileset</string>
+         <string>Generate</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QPushButton" name="saveButton">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="text">
+         <string>Save</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="Line" name="line">
+        <property name="orientation">
+         <enum>Qt::Vertical</enum>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QPushButton" name="optionsButton">
+        <property name="text">
+         <string>Options editor</string>
         </property>
        </widget>
       </item>
@@ -111,26 +141,6 @@
      </widget>
     </item>
    </layout>
-  </widget>
-  <widget class="QMenuBar" name="menuBar">
-   <property name="geometry">
-    <rect>
-     <x>0</x>
-     <y>0</y>
-     <width>711</width>
-     <height>20</height>
-    </rect>
-   </property>
-   <widget class="QMenu" name="menuWangscape_GUI">
-    <property name="title">
-     <string>File</string>
-    </property>
-    <addaction name="actionLoadOptions"/>
-    <addaction name="actionOpenOptionsEditor"/>
-    <addaction name="separator"/>
-    <addaction name="actionSaveOutput"/>
-   </widget>
-   <addaction name="menuWangscape_GUI"/>
   </widget>
   <action name="actionLoadOptions">
    <property name="text">

--- a/WangscapeGui/OptionsEditor.cpp
+++ b/WangscapeGui/OptionsEditor.cpp
@@ -25,6 +25,7 @@ OptionsEditor::OptionsEditor(QWidget *parent_) :
 
     connect(mUi->alphaCalculatorModeComboBox, SIGNAL(activated(const QString&)), this, SLOT(setAlphaCalculatorMode(const QString&)));
     connect(mUi->restoreOptionsButton, SIGNAL(pressed()), this->parent(), SLOT(resetOptions()));
+    connect(mUi->loadOptionsButton, SIGNAL(pressed()), this->parent(), SLOT(loadOptionsFromFile()));
     connect(mUi->defaultOuputDirCheckBox, SIGNAL(stateChanged(int)), this, SLOT(switchDefaultOutputDirFlag(int)));
 }
 

--- a/WangscapeGui/OptionsEditor.ui
+++ b/WangscapeGui/OptionsEditor.ui
@@ -19,7 +19,7 @@
   <property name="minimumSize">
    <size>
     <width>220</width>
-    <height>150</height>
+    <height>167</height>
    </size>
   </property>
   <property name="windowTitle">
@@ -42,7 +42,7 @@
     <item>
      <widget class="QTabWidget" name="tabWidget">
       <property name="currentIndex">
-       <number>1</number>
+       <number>0</number>
       </property>
       <widget class="QWidget" name="alphaTab">
        <attribute name="title">
@@ -65,67 +65,60 @@
          <number>0</number>
         </property>
         <item>
-         <layout class="QVBoxLayout" name="verticalLayout_2" stretch="0">
+         <layout class="QVBoxLayout" name="verticalLayout_3" stretch="0,0,0">
           <property name="spacing">
-           <number>1</number>
+           <number>5</number>
+          </property>
+          <property name="sizeConstraint">
+           <enum>QLayout::SetDefaultConstraint</enum>
+          </property>
+          <property name="leftMargin">
+           <number>5</number>
+          </property>
+          <property name="topMargin">
+           <number>5</number>
+          </property>
+          <property name="rightMargin">
+           <number>5</number>
           </property>
           <item>
-           <layout class="QVBoxLayout" name="verticalLayout_3" stretch="0,0,0">
-            <property name="spacing">
-             <number>5</number>
+           <widget class="QLabel" name="label">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
             </property>
-            <property name="sizeConstraint">
-             <enum>QLayout::SetDefaultConstraint</enum>
+            <property name="text">
+             <string>Alpha calculator mode</string>
             </property>
-            <property name="leftMargin">
-             <number>5</number>
+           </widget>
+          </item>
+          <item>
+           <widget class="QComboBox" name="alphaCalculatorModeComboBox">
+            <property name="enabled">
+             <bool>true</bool>
             </property>
-            <property name="topMargin">
-             <number>5</number>
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
             </property>
-            <property name="rightMargin">
-             <number>5</number>
+           </widget>
+          </item>
+          <item>
+           <spacer name="verticalSpacer">
+            <property name="orientation">
+             <enum>Qt::Vertical</enum>
             </property>
-            <item>
-             <widget class="QLabel" name="label">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="text">
-               <string>Alpha calculator mode</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QComboBox" name="alphaCalculatorModeComboBox">
-              <property name="enabled">
-               <bool>true</bool>
-              </property>
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <spacer name="verticalSpacer">
-              <property name="orientation">
-               <enum>Qt::Vertical</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>20</width>
-                <height>40</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-           </layout>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>20</width>
+              <height>40</height>
+             </size>
+            </property>
+           </spacer>
           </item>
          </layout>
         </item>
@@ -184,6 +177,19 @@
     </item>
     <item>
      <layout class="QHBoxLayout" name="horizontalLayout">
+      <item>
+       <widget class="QPushButton" name="loadOptionsButton">
+        <property name="font">
+         <font>
+          <weight>75</weight>
+          <bold>true</bold>
+         </font>
+        </property>
+        <property name="text">
+         <string>Load</string>
+        </property>
+       </widget>
+      </item>
       <item>
        <widget class="QPushButton" name="restoreOptionsButton">
         <property name="text">


### PR DESCRIPTION
Fixes #178.

Before loading options almost all buttons are disabled to suggest that options should be loaded before any other action:
![tmp tig98dlhh8](https://user-images.githubusercontent.com/344521/30297242-66965590-9747-11e7-9616-704910316291.png)

After loading an options file, "Generate" button becomes active:
![tmp uizyyh7kez](https://user-images.githubusercontent.com/344521/30297361-d4499548-9747-11e7-9bae-93d5391831bf.png)


...and when user clicks on it, "Save" button allows saving output tilesets and metaoutput:
![tmp g1dfimcfin](https://user-images.githubusercontent.com/344521/30297323-b0a9a042-9747-11e7-9ba4-9d8a1a79d63b.png)

