### PR TITLE
Add libarmadillo-dev to pre-requisite installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ First, install necessary packages with `apt`:
 ```shell
 apt install cmake g++ libsfml-dev libboost-system-dev \
     libboost-filesystem-dev libboost-program-options-dev \
-    qt5-default
+    qt5-default libarmadillo-dev
 ```
 
 ### Compilation


### PR DESCRIPTION
Just found out the hard way that `libarmadillo-dev` is missing from the pre-requisite installation instructions for Ubuntu linux.

(by the way, how do you manage to have my shell print that annoying warning message about CRLF and LF everytime I execute a command inside the Wangscape repo? It's incredibly weird and amazing at the same time)