### PR TITLE
Update invocation of Wangcheck package script

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -85,7 +85,7 @@ after_build:
     
     Set-Item Env:PYTHON "C:\Python36"
     
-    C:package.bat
+    & .\package.ps1
     
     cd ..
     


### PR DESCRIPTION
Moved from `package.bat` to `package.ps1` in https://github.com/Wangscape/Wangcheck/pull/10.

Fixes https://ci.appveyor.com/project/serin-delaunay/wangscape/build/0.1.346#L861.